### PR TITLE
Add Portable schema adapter

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/ma1a_portable_schema.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/ma1a_portable_schema.yml
@@ -1,0 +1,167 @@
+---
+comment: |
+  Adapter between the package-level MA 1A / Portable schema and this
+  interview's existing local variables.
+
+  The canonical party objects for the shared 1A package are:
+    - petitioners[0]
+    - petitioners[1]
+
+  This interview already uses users[0] and users[1] internally. Keep that
+  stable for the interview and PDF mappings, while accepting and exporting
+  the canonical petitioner objects at the package boundary.
+---
+code: |
+  # Import package-level aliases when Portable or a parent interview pre-fills
+  # canonical values.
+  if defined("petitioners[0].name.first") and not defined("users[0].name.first"):
+    users[0].name.first = petitioners[0].name.first
+  if defined("petitioners[0].name.middle") and not defined("users[0].name.middle"):
+    users[0].name.middle = petitioners[0].name.middle
+  if defined("petitioners[0].name.last") and not defined("users[0].name.last"):
+    users[0].name.last = petitioners[0].name.last
+  if defined("petitioners[0].name.suffix") and not defined("users[0].name.suffix"):
+    users[0].name.suffix = petitioners[0].name.suffix
+  if defined("petitioners[0].address.address") and not defined("users[0].address.address"):
+    users[0].address.address = petitioners[0].address.address
+  if defined("petitioners[0].address.unit") and not defined("users[0].address.unit"):
+    users[0].address.unit = petitioners[0].address.unit
+  if defined("petitioners[0].address.city") and not defined("users[0].address.city"):
+    users[0].address.city = petitioners[0].address.city
+  if defined("petitioners[0].address.state") and not defined("users[0].address.state"):
+    users[0].address.state = petitioners[0].address.state
+  if defined("petitioners[0].address.zip") and not defined("users[0].address.zip"):
+    users[0].address.zip = petitioners[0].address.zip
+  if defined("petitioners[0].address.county") and not defined("users[0].address.county"):
+    users[0].address.county = petitioners[0].address.county
+  if defined("petitioners[0].phone_number") and not defined("users[0].phone_number"):
+    users[0].phone_number = petitioners[0].phone_number
+  if defined("petitioners[0].email") and not defined("users[0].email"):
+    users[0].email = petitioners[0].email
+  if defined("petitioners[0].birthdate") and not defined("users[0].birthdate"):
+    users[0].birthdate = petitioners[0].birthdate
+  if defined("petitioners[0].ssn") and not defined("users[0].ssn"):
+    users[0].ssn = petitioners[0].ssn
+  if defined("petitioners[0].name_change") and not defined("users[0].name_change"):
+    users[0].name_change = petitioners[0].name_change
+  if defined("petitioners[0].former_name_last") and not defined("users[0].former_name_last"):
+    users[0].former_name_last = petitioners[0].former_name_last
+  if defined("petitioners[0].has_attorney") and not defined("users[0].has_attorney"):
+    users[0].has_attorney = petitioners[0].has_attorney
+
+  if defined("petitioners[1].name.first") and not defined("users[1].name.first"):
+    users[1].name.first = petitioners[1].name.first
+  if defined("petitioners[1].name.middle") and not defined("users[1].name.middle"):
+    users[1].name.middle = petitioners[1].name.middle
+  if defined("petitioners[1].name.last") and not defined("users[1].name.last"):
+    users[1].name.last = petitioners[1].name.last
+  if defined("petitioners[1].name.suffix") and not defined("users[1].name.suffix"):
+    users[1].name.suffix = petitioners[1].name.suffix
+  if defined("petitioners[1].address.address") and not defined("users[1].address.address"):
+    users[1].address.address = petitioners[1].address.address
+  if defined("petitioners[1].address.unit") and not defined("users[1].address.unit"):
+    users[1].address.unit = petitioners[1].address.unit
+  if defined("petitioners[1].address.city") and not defined("users[1].address.city"):
+    users[1].address.city = petitioners[1].address.city
+  if defined("petitioners[1].address.state") and not defined("users[1].address.state"):
+    users[1].address.state = petitioners[1].address.state
+  if defined("petitioners[1].address.zip") and not defined("users[1].address.zip"):
+    users[1].address.zip = petitioners[1].address.zip
+  if defined("petitioners[1].address.county") and not defined("users[1].address.county"):
+    users[1].address.county = petitioners[1].address.county
+  if defined("petitioners[1].phone_number") and not defined("users[1].phone_number"):
+    users[1].phone_number = petitioners[1].phone_number
+  if defined("petitioners[1].email") and not defined("users[1].email"):
+    users[1].email = petitioners[1].email
+  if defined("petitioners[1].birthdate") and not defined("users[1].birthdate"):
+    users[1].birthdate = petitioners[1].birthdate
+  if defined("petitioners[1].ssn") and not defined("users[1].ssn"):
+    users[1].ssn = petitioners[1].ssn
+  if defined("petitioners[1].name_change") and not defined("users[1].name_change"):
+    users[1].name_change = petitioners[1].name_change
+  if defined("petitioners[1].former_name_last") and not defined("users[1].former_name_last"):
+    users[1].former_name_last = petitioners[1].former_name_last
+  if defined("petitioners[1].has_attorney") and not defined("users[1].has_attorney"):
+    users[1].has_attorney = petitioners[1].has_attorney
+
+  if defined("has_children_of_marriage") and not defined("children_of_marriage"):
+    children_of_marriage = has_children_of_marriage
+
+  ma1a_apply_portable_schema = True
+---
+code: |
+  # Export the local interview values back to canonical package names.
+  if defined("users[0].name.first") and not defined("petitioners[0].name.first"):
+    petitioners[0].name.first = users[0].name.first
+  if defined("users[0].name.middle") and not defined("petitioners[0].name.middle"):
+    petitioners[0].name.middle = users[0].name.middle
+  if defined("users[0].name.last") and not defined("petitioners[0].name.last"):
+    petitioners[0].name.last = users[0].name.last
+  if defined("users[0].name.suffix") and not defined("petitioners[0].name.suffix"):
+    petitioners[0].name.suffix = users[0].name.suffix
+  if defined("users[0].address.address") and not defined("petitioners[0].address.address"):
+    petitioners[0].address.address = users[0].address.address
+  if defined("users[0].address.unit") and not defined("petitioners[0].address.unit"):
+    petitioners[0].address.unit = users[0].address.unit
+  if defined("users[0].address.city") and not defined("petitioners[0].address.city"):
+    petitioners[0].address.city = users[0].address.city
+  if defined("users[0].address.state") and not defined("petitioners[0].address.state"):
+    petitioners[0].address.state = users[0].address.state
+  if defined("users[0].address.zip") and not defined("petitioners[0].address.zip"):
+    petitioners[0].address.zip = users[0].address.zip
+  if defined("users[0].address.county") and not defined("petitioners[0].address.county"):
+    petitioners[0].address.county = users[0].address.county
+  if defined("users[0].phone_number") and not defined("petitioners[0].phone_number"):
+    petitioners[0].phone_number = users[0].phone_number
+  if defined("users[0].email") and not defined("petitioners[0].email"):
+    petitioners[0].email = users[0].email
+  if defined("users[0].birthdate") and not defined("petitioners[0].birthdate"):
+    petitioners[0].birthdate = users[0].birthdate
+  if defined("users[0].ssn") and not defined("petitioners[0].ssn"):
+    petitioners[0].ssn = users[0].ssn
+  if defined("users[0].name_change") and not defined("petitioners[0].name_change"):
+    petitioners[0].name_change = users[0].name_change
+  if defined("users[0].former_name_last") and not defined("petitioners[0].former_name_last"):
+    petitioners[0].former_name_last = users[0].former_name_last
+  if defined("users[0].has_attorney") and not defined("petitioners[0].has_attorney"):
+    petitioners[0].has_attorney = users[0].has_attorney
+
+  if defined("users[1].name.first") and not defined("petitioners[1].name.first"):
+    petitioners[1].name.first = users[1].name.first
+  if defined("users[1].name.middle") and not defined("petitioners[1].name.middle"):
+    petitioners[1].name.middle = users[1].name.middle
+  if defined("users[1].name.last") and not defined("petitioners[1].name.last"):
+    petitioners[1].name.last = users[1].name.last
+  if defined("users[1].name.suffix") and not defined("petitioners[1].name.suffix"):
+    petitioners[1].name.suffix = users[1].name.suffix
+  if defined("users[1].address.address") and not defined("petitioners[1].address.address"):
+    petitioners[1].address.address = users[1].address.address
+  if defined("users[1].address.unit") and not defined("petitioners[1].address.unit"):
+    petitioners[1].address.unit = users[1].address.unit
+  if defined("users[1].address.city") and not defined("petitioners[1].address.city"):
+    petitioners[1].address.city = users[1].address.city
+  if defined("users[1].address.state") and not defined("petitioners[1].address.state"):
+    petitioners[1].address.state = users[1].address.state
+  if defined("users[1].address.zip") and not defined("petitioners[1].address.zip"):
+    petitioners[1].address.zip = users[1].address.zip
+  if defined("users[1].address.county") and not defined("petitioners[1].address.county"):
+    petitioners[1].address.county = users[1].address.county
+  if defined("users[1].phone_number") and not defined("petitioners[1].phone_number"):
+    petitioners[1].phone_number = users[1].phone_number
+  if defined("users[1].email") and not defined("petitioners[1].email"):
+    petitioners[1].email = users[1].email
+  if defined("users[1].birthdate") and not defined("petitioners[1].birthdate"):
+    petitioners[1].birthdate = users[1].birthdate
+  if defined("users[1].ssn") and not defined("petitioners[1].ssn"):
+    petitioners[1].ssn = users[1].ssn
+  if defined("users[1].name_change") and not defined("petitioners[1].name_change"):
+    petitioners[1].name_change = users[1].name_change
+  if defined("users[1].former_name_last") and not defined("petitioners[1].former_name_last"):
+    petitioners[1].former_name_last = users[1].former_name_last
+  if defined("users[1].has_attorney") and not defined("petitioners[1].has_attorney"):
+    petitioners[1].has_attorney = users[1].has_attorney
+
+  if defined("children_of_marriage") and not defined("has_children_of_marriage"):
+    has_children_of_marriage = children_of_marriage
+
+  ma1a_export_portable_schema = True

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main.yml
@@ -3,6 +3,7 @@ include:
   - docassemble.AssemblyLine:assembly_line.yml
   - docassemble.ALMassachusetts:al_massachusetts.yml
   - docassemble.MassAccess:massaccess.yml
+  - ma1a_portable_schema.yml
   #- 209A_affidavit_disclosing_care_or_custody_proceedings.yml
   #- Financial statement interview
   #- Separation agreement interview
@@ -101,6 +102,7 @@ code: |
   al_form_type = "starts_case" 
 ---
 objects:
+  - petitioners: ALPeopleList.using(ask_number=False, target_number=2)
   - users: ALPeopleList.using(ask_number=False, target_number=2)
   - children: ALPeopleList.using(ask_number=False)
   - attorneys: ALPeopleList.using(ask_number=False)
@@ -126,6 +128,7 @@ code: |
   allowed_courts = ['Probate and Family Court']
   user_role = "plaintiff"
   user_ask_role = "plaintiff"
+  ma1a_apply_portable_schema
   
   nav.set_section("divorce_eligibility")
   legal_marriage
@@ -206,6 +209,7 @@ code: |
   nav.set_section("review_and_sign")
 
   set_default_petition_values
+  ma1a_export_portable_schema
   
   interview_order_divorcejointpetition = True
 ---


### PR DESCRIPTION
## Summary

- Adds a small `ma1a_portable_schema.yml` adapter for the shared MA 1A / Portable schema.
- Keeps the existing Joint Petition internals (`users[0]` / `users[1]`) intact.
- Imports/exports canonical package-facing petitioner values through `petitioners[0]` and `petitioners[1]`.
- Maps children-of-marriage boolean aliases without changing the existing interview flow or PDF mappings.

## Why

This gives the combined 1A / Portable flow stable shared variable names without doing a risky repo-wide variable rename in the standalone interview.

## Validation

- `python3` YAML parse across all question YAML files
- Embedded Python `code:` block syntax check with `ast.parse`
- `git diff --check`
- Local Docker before/after render smoke test against current `origin/main` and this branch:
  - `/api/session/new` returned 200
  - first question render returned 200
  - after submitting `al_intro_screen=True` and `acknowledged_information_use=True`, the next rendered screen matched baseline: `Joint 1A Divorce Intro`
- Local Docker full walkthrough on this branch:
  - completed successfully in 33 steps
  - reached terminal screen `download divorce joint petition`
  - downloaded `divorcejointpetition.pdf` and `affidavit.pdf`
  - PDF assertions passed for docket number, party names, party addresses, marriage location, marital home address, no-fault divorce request, phone fields, and affidavit breakdown text