### PR TITLE
[codex] Define optional care custody documents

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -197,6 +197,10 @@ code: |
   a_divorce_agreement_Post_interview_instructions.enabled = include_separation_agreement
   a_divorce_agreement_attachment.enabled = include_separation_agreement
 ---
+objects:
+  - child_care_or_custody_disclosure_affidavit_next_steps: ALDocument.using(title="Care or custody affidavit instructions", filename="care_or_custody_affidavit_next_steps", has_addendum=False)
+  - affidavit_of_care_or_custody_attachment: ALDocument.using(title="Affidavit disclosing care or custody proceedings", filename="affidavit_disclosing_care_or_custody", has_addendum=False)
+---
 # Bundles group the ALDocuments into separate downloads, such as for court and for the user
 objects:
   - al_user_bundle: ALDocumentBundle.using(elements=[divorcejointpetition_Post_interview_instructions, divorcejointpetition_attachment, affidavit_attachment, affidavitofindigency_attachment, child_care_or_custody_disclosure_affidavit_next_steps, affidavit_of_care_or_custody_attachment, users[0].financial_statement_short_attachment, users[0].financial_statement_long_attachment, users[0].financial_statement_schedule_a_attachment, users[0].financial_statement_schedule_b_attachment, users[1].financial_statement_short_attachment, users[1].financial_statement_long_attachment, users[1].financial_statement_schedule_a_attachment, users[1].financial_statement_schedule_b_attachment, a_divorce_agreement_Post_interview_instructions, a_divorce_agreement_attachment], filename="joint_petition_divorce_packet", title="All forms to download for your records", enabled=True)


### PR DESCRIPTION
## Summary

Defines the care/custody `ALDocument` objects referenced by the joint petition final bundle.

## Why

The final bundle includes `child_care_or_custody_disclosure_affidavit_next_steps` and `affidavit_of_care_or_custody_attachment` even when the user does not include the care/custody affidavit. In the no-child/no-care-custody path, those variables can otherwise be filled incorrectly by API automation or remain unavailable during final bundle evaluation.

This PR keeps the existing `docassemble.MATCChildCareOrCustodyDisclosureAffidavit` integration in place.

## Validation

Locally deployed into the docassemble Docker container with `docassemble.MATCChildCareOrCustodyDisclosureAffidavit` installed editable and ran `scripts/run_docassemble_api.py` end to end through the docassemble API. The interview reached `All done` and produced the final download screen with petition, affidavit/fee waiver, two financial statements, separation agreement, instructions, and combined packet downloads.