### PR TITLE
Fix optional form flow through final download

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -950,7 +950,7 @@ progress: 100
 # ALDocument objects specify the metadata for each template
 objects:
   - divorcejointpetition_Post_interview_instructions: ALDocument.using(title="Instructions", filename="divorcejointpetition_next_steps.docx", has_addendum=False)
-  - divorcejointpetition_attachment: ALDocument.using(title="Joint1ADivorce", filename="divorcejointpetition", has_addendum=True, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+  - divorcejointpetition_attachment: ALDocument.using(title="Joint1ADivorce", filename="divorcejointpetition", has_addendum=False)
   - affidavit_attachment: ALDocument.using(title="Affidavit", filename="affidavit", has_addendum=False, )
 ---
 # Each attachment defines a key in an ALDocument. We use `i` as the placeholder here so the same template is 

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -277,6 +277,10 @@ code: |
 
   interview_order_divorcejointpetition
 
+  nav.set_section("court_requests")
+  trial_court
+  set_trial_court_division
+
   include_care_or_custody_affidavit = children_of_marriage
   if include_care_or_custody_affidavit:
     set_care_or_custody_affidavit_defaults
@@ -292,6 +296,7 @@ code: |
 
   if include_financial_statement:
     nav.set_section("financial_statement")
+    financial_statement_court_division = trial_court.division
     interview_order_financial_statement
 
   if include_separation_agreement:
@@ -304,6 +309,11 @@ code: |
     ask_affidavit_questions
 
   joint_petition_interview_order = True
+---
+code: |
+  court_name = str(trial_court)
+  trial_court.division = court_name.replace(" Probate and Family Court - North", "").replace(" Probate and Family Court - South", "").replace(" Probate and Family Court", "")
+  set_trial_court_division = True
 ---
 code: |
   other_parties.there_are_any = False
@@ -358,10 +368,6 @@ code: |
   )
   divorcejointpetition_preview_question
   basic_questions_signature_flow
-  users1_signature
-  users2_signature
-  users2_petition_signature
-  users1_petition_signature
 
   if not defined("divorcejointpetition_downloads_ready"):
     if al_user_bundle.generate_downloads_with_docx_task.ready():


### PR DESCRIPTION
Summary
- Collect the court before entering optional subinterviews.
- Reuse the court division for the financial statement.
- Remove old signature prompts from the final order block.
- Fix the joint petition document setup so the final packet can download.

Checks
- YAML files parse.
- Whitespace diff check passes.
- The combined fixed package was walked through to final download across the main no-children path, the Child Tax Claim path, and the care/custody affidavit path.

Closes #59