### PR TITLE
Fix combined agreement signing and child support navigation

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -746,16 +746,6 @@ question: |
   ${  users[1]  }, sign below
 signature: users[1].signature
 ---
-id: sign attorney A
-question: |
-  ${  attorneys[0]  }, sign below
-signature: users[0].signature
----
-id: sign attorney B
-question: |
-  ${  attorneys[1]  }, sign below
-signature: users[1].signature
----
 code: |
   users.there_is_another = False
 ---

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -121,6 +121,7 @@ sections:
   - child_info: Agreement child information
   - child_custody: Agreement custody
   - parenting_time: Agreement parenting time
+  - child_support: Agreement child support
   - adult_health_insurance: Agreement health insurance
   - child_health_insurance: Agreement children's health insurance
   - education: Agreement education costs
@@ -247,6 +248,7 @@ data:
   - child_info: Agreement child information
   - child_custody: Agreement custody
   - parenting_time: Agreement parenting time
+  - child_support: Agreement child support
   - adult_health_insurance: Agreement health insurance
   - child_health_insurance: Agreement children's health insurance
   - education: Agreement education costs


### PR DESCRIPTION
## Summary
- adds the child support navigation section used by the included separation agreement
- removes duplicate attorney signature screens that could be reached when no attorney was entered

## Checks
- checked the combined 1A path with children and the built-in separation agreement through the final screen
- checked the financial statement path through document generation

This is separate from the larger separation agreement YAML cleanup.