### PR TITLE
Reuse separation agreement answers in the joint petition

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -103,7 +103,9 @@ code: |
     set_parts(subtitle=str(children))
     users1_number_of_custodial_children
   nav.set_section("court_requests")  
-  request_merge_agreement
+  if separation_agreement_format != "interview":
+    request_merge_agreement
+    request_survive_agreement
   users[0].name_change
   additional_request
   
@@ -851,10 +853,12 @@ review:
       **When did the marriage breakdown occur?**:
       ${ marriage_breakdown_date }
   - Edit: request_merge_agreement
+    show if: separation_agreement_format != "interview"
     button: |
       **Request merge agreement**:
       ${ request_merge_agreement }
   - Edit: request_survive_agreement
+    show if: separation_agreement_format != "interview"
     button: |
       **Request survive agreement**:
       ${ request_survive_agreement }

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -399,6 +399,10 @@ code: |
     interview_order_financial_statement
 
   if include_separation_agreement:
+    # The parent interview has already collected this shared child information.
+    has_children = children_of_marriage
+    if has_children:
+      children.target_number = len(children)
     interview_order_a_divorce_agreement
 
   if include_findings_and_determinations:

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -404,6 +404,7 @@ code: |
     if has_children:
       children.target_number = len(children)
     interview_order_a_divorce_agreement
+    set_petition_merger_survival_from_agreement
 
   if include_findings_and_determinations:
     set_findings_and_determinations_defaults
@@ -418,6 +419,16 @@ code: |
     ask_affidavit_questions
 
   joint_petition_interview_order = True
+---
+depends on:
+  - has_children
+  - provisions_that_merge
+code: |
+  request_merge_agreement = (
+    has_children or not provisions_that_merge.all_false()
+  )
+  request_survive_agreement = True
+  set_petition_merger_survival_from_agreement = True
 ---
 code: |
   court_name = str(trial_court)


### PR DESCRIPTION
Reuses answers when the separation agreement is included in the joint petition:
- the child answer and child list
- the agreement's detailed merger/survival terms

The standalone agreement is unchanged. Upload and later-agreement paths continue to ask the existing merger/survival question.