### PR TITLE
Update joint petition introduction

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -148,28 +148,20 @@ continue button field: divorcejointpetition_intro
 question: |
    **Joint petition for divorce under [G.L. c. 208, § 1A](https://malegislature.gov/Laws/GeneralLaws/PartII/TitleIII/Chapter208/Section1a)**
 subquestion: |
-    This interview will help you jointly ask the court for a no-fault divorce.
+    This interview helps both spouses prepare a packet for a joint divorce. This is called a 1A divorce.
 
-    You should file for a 1A divorce when both spouses agree the marriage has irretrievably broken down and can't continue.
-  
-    **Before you get started, please gather:**
-  
-    1. Certified Copy of Marriage Certificate
-    2. Notarized Separation Agreement (if already prepared) 
-    3. Names, birthdays, and addresses for both parties and all minor children of the marriage
-    4. Monthly budget or finance tracking information
-    5. Recent pay stubs 
-    
-    **When you are finished, you will need to:**
-  
-    1. File Notarized Separation Agreement (unless uploaded) 
-    2. File Certified Copy of Marriage Certificate (unless uploaded) 
-    3. File financial statements for each petitioner (unless completed)
-     
-    If child support is being addressed or waived:
-    
-    1. File child support guidelines worksheet (CJ-D 304)
-    2. File findings and determinations for child support and post-secondary education (CJ-D 305)
+    It asks about your marriage, your agreement, and any children.
+
+    **Before you begin, gather these documents and details.**
+
+    1. A copy of your marriage certificate, if you have one
+    2. Your separation agreement, if you have one
+    3. Names, birth dates, and addresses for both spouses and any children under 18
+    4. Pay stubs and details about your income and costs, if you want financial forms
+
+    **At the end**
+
+    You can download your papers. The last screen tells you what to do before you file.
 
 ---
 id: Party B name


### PR DESCRIPTION
## What changed

Updated the joint-petition introduction to explain the packet in plain language, give a shorter preparation list, and point users to the final screen for their next steps.

## Why

The earlier checklist was written for the standalone interview and promised documents that not every packet produces.

## Checked

The YAML parses successfully. The revised screen reads at a 6th to 7th grade level.
