### PR TITLE
Clarify agreement notarization before filing

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -701,6 +701,11 @@ subquestion: |
   ${ action_button_html(url_action('review_divorcejointpetition'), label='Edit answers', color='info') }
   
   When your answers are correct, continue to sign your forms.
+
+  % if separation_agreement_format == "interview":
+  **Before filing your separation agreement:** Both spouses must sign it in
+  front of a notary. The signatures entered here do not replace notarization.
+  % endif
 continue button field: divorcejointpetition_preview_question    
 ---
 code: |

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -703,8 +703,7 @@ subquestion: |
   When your answers are correct, continue to sign your forms.
 
   % if separation_agreement_format == "interview":
-  **Before filing your separation agreement:** Both spouses must sign it in
-  front of a notary. The signatures entered here do not replace notarization.
+  **Before filing your separation agreement:** Each spouse must sign it in front of a notary public. The signatures you enter in this online interview do not replace notarization.
   % endif
 continue button field: divorcejointpetition_preview_question    
 ---


### PR DESCRIPTION
## Summary

Adds a brief notice that signatures entered in the interview do not replace
notarization before the separation agreement is filed.

Part of #32.