### PR TITLE
Add ODR import intake review screen

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -969,9 +969,8 @@ review:
       - users2_number_of_custodial_children
     show if: children_of_marriage
     button: |
-      **Custodial children counts**:
-      * ${ users[0].familiar() }: ${ users1_number_of_custodial_children }
-      * ${ users[1].familiar() }: ${ users2_number_of_custodial_children }
+      * ${ users[0].familiar() }: ${ users1_number_of_custodial_children if defined("users1_number_of_custodial_children") else "Not provided" }
+      * ${ users[1].familiar() }: ${ users2_number_of_custodial_children if defined("users2_number_of_custodial_children") else "Not provided" }
   - note: |
       ## Separation agreement and filing documents
   - Edit: separation_agreement_format

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -878,6 +878,116 @@ review:
       **Attorney 2 BBO number**:
       ${ attorneys2_bbo_number }
 ---
+id: odr import review screen
+event: review_odr_import
+question: |
+  Review your imported ODR information
+subquestion: |
+  We imported this information from the ODR platform when you entered this interview.
+  Review each section before you continue. You can edit anything that is incorrect.
+review:
+  - note: |
+      ## Case information
+  - Edit: trial_court
+    button: |
+      **Trial court**
+
+      % if defined("trial_court.address.county"):
+      * address: ${ trial_court.address.block() }
+      % endif
+  - Edit: docket_number
+    button: |
+      **Docket number**:
+      ${ docket_number }
+  - Edit: previous_action
+    button: |
+      **Existing 1B case to convert**:
+      ${ word(yesno(previous_action)) }
+  - Edit: previous_action_detail
+    show if: previous_action
+    button: |
+      **Existing case details**:
+      > ${ single_paragraph(previous_action_detail) }
+  - note: |
+      ## Parties
+  - Edit: users.revisit
+    button: |
+      **Users**
+
+      % for item in users:
+        * ${ item }
+      % endfor
+  - Edit: attorneys.revisit
+    button: |
+      **Attorneys**
+
+      % for item in attorneys:
+        * ${ item }
+      % endfor
+  - note: |
+      ## Marriage information
+  - Edit: marriage_date
+    button: |
+      **Date of marriage**:
+      ${ marriage_date }
+  - Edit: marriage_city
+    button: |
+      **City where marriage took place**:
+      ${ marriage_city }
+  - Edit: marriage_state
+    button: |
+      **State where marriage took place**:
+      ${ marriage_state }
+  - Edit: marriage_country
+    button: |
+      **Country where marriage took place**:
+      ${ marriage_country }
+  - Edit: last_living_together_date
+    button: |
+      **Last date living together**:
+      ${ last_living_together_date }
+  - Edit: marriage_breakdown_date
+    button: |
+      **Marriage breakdown date**:
+      ${ marriage_breakdown_date }
+  - note: |
+      ## Children and support
+  - Edit: children_of_marriage
+    button: |
+      **Children of the marriage**:
+      ${ word(yesno(children_of_marriage)) }
+  - Edit: children.revisit
+    show if: children_of_marriage
+    button: |
+      **Children**
+
+      % for child in children:
+        * ${ child }
+      % endfor
+  - Edit:
+      - users1_number_of_custodial_children
+      - users2_number_of_custodial_children
+    show if: children_of_marriage
+    button: |
+      **Custodial children counts**:
+      * ${ users[0].familiar() }: ${ users1_number_of_custodial_children }
+      * ${ users[1].familiar() }: ${ users2_number_of_custodial_children }
+  - note: |
+      ## Separation agreement and filing documents
+  - Edit: separation_agreement_format
+    button: |
+      **How separation agreement is provided**:
+      ${ separation_agreement_format }
+  - Edit: separation_agreement_upload
+    show if: separation_agreement_format == "upload"
+    button: |
+      **Uploaded separation agreement**:
+      ${ separation_agreement_upload.filename if defined("separation_agreement_upload.filename") else "Uploaded" }
+  - Edit: marriage_certificate_upload
+    button: |
+      **Certified marriage certificate**:
+      ${ marriage_certificate_upload.filename if defined("marriage_certificate_upload.filename") else "Uploaded" }
+---
 id: edit users
 continue button field: users.revisit
 question: |


### PR DESCRIPTION
## Why
Users entering from the ODR platform need a clear confirmation step to review transferred case data before continuing through the rest of the interview.

## What changed
This adds a new docassemble review event, `review_odr_import`, in `divorce_joint_petition.yml` that is structured as an import-first intake review.

The screen groups imported data into focused sections with edit controls:
- Case information
- Parties
- Marriage information
- Children and support
- Separation agreement and filing documents

Each section reuses existing interview variables and revisit patterns (`users.revisit`, `attorneys.revisit`, `children.revisit`) so users can correct imported answers immediately from the review screen.

## Notes for reviewers
This is an additive change only: a new review-screen block and event definition. It does not remove or refactor the existing end-of-interview review flow.