### PR TITLE
Fix merge agreement interview loop

### DIFF
--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -480,11 +480,11 @@ code: |
   joint_petition_interview_order = True
 ---
 depends on:
-  - has_children
+  - children_of_marriage
   - provisions_that_merge
 code: |
   request_merge_agreement = (
-    has_children or not provisions_that_merge.all_false()
+    children_of_marriage or not provisions_that_merge.all_false()
   )
   request_survive_agreement = True
   set_petition_merger_survival_from_agreement = True


### PR DESCRIPTION
Prevent an infinite interview loop when a separation agreement is uploaded or delayed. `request_merge_agreement` now uses the always-defined `children_of_marriage` value instead of the branch-local `has_children` alias.