### PR TITLE
Add exhaustive combined-interview certification gate

### DIFF
--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -83,6 +83,7 @@ jobs:
           path: docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
 
       - name: Start disposable Docassemble server
+        timeout-minutes: 15
         run: |
           da_key=$(openssl rand -hex 16)
           da_password=$(openssl rand -base64 24)

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -182,6 +182,19 @@ jobs:
             --ledger tests/certification/artifacts/runtime-ledger.json \
             --output tests/certification/artifacts/coverage-audit.json
 
+      - name: Reject background worker task errors
+        if: always()
+        run: |
+          artifact_dir=docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
+          mkdir -p "$artifact_dir"
+          docker cp "$DA_CONTAINER:/usr/share/docassemble/log/worker.log" \
+            "$artifact_dir/worker.log"
+          if grep -E "Task tasks\..*raised unexpected|Could not retrieve file" \
+            "$artifact_dir/worker.log"; then
+            echo "Docassemble recorded an unexpected background worker failure."
+            exit 1
+          fi
+
       - name: Capture runtime resource diagnostics
         if: always()
         continue-on-error: true

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -92,6 +92,7 @@ jobs:
             --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
             --env DA_ADMIN_PASSWORD="$da_password" \
             --env DA_ADMIN_API_KEY="$da_key" \
+            --env DACELERYWORKERS=2 \
             --cap-add SYS_PTRACE \
             --memory 6gb \
             --stop-timeout 60 \

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -193,7 +193,7 @@ jobs:
             "ps -eo pid,%cpu,args --sort=-%cpu | awk '\$0 ~ /celery/ && \$0 !~ /awk/ {print \$1; exit}'")
           if [ -n "$worker_pid" ]; then
             docker exec "$DA_CONTAINER" bash -lc \
-              "pyspy_bin=\$(find /usr/share/docassemble -maxdepth 3 -path '*/local3.*/bin/py-spy' -print -quit); test -n \"\$pyspy_bin\"; timeout 30s \"\$pyspy_bin\" dump --native --pid '$worker_pid'" \
+              "pyspy_bin=\$(find /usr/share/docassemble -maxdepth 3 -path '*/local3.*/bin/py-spy' -print -quit); test -n \"\$pyspy_bin\"; timeout 30s \"\$pyspy_bin\" dump --pid '$worker_pid'" \
               > "$artifact_dir/worker-stack.txt" 2>&1 || true
           fi
 

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -160,6 +160,11 @@ jobs:
             --image docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docker-image.json \
             --pip-freeze docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/pip-freeze.txt
 
+      - name: Install disposable runtime profiler
+        run: |
+          docker exec "$DA_CONTAINER" bash -lc \
+            'python_bin=$(find /usr/share/docassemble -maxdepth 3 -path "*/local3.*/bin/python" -print -quit); test -n "$python_bin"; "$python_bin" -m pip install py-spy==0.4.1'
+
       - name: Run every modeled path
         id: crawl
         continue-on-error: true
@@ -192,6 +197,13 @@ jobs:
           docker stats --no-stream "$DA_CONTAINER" > "$artifact_dir/docker-stats.txt"
           docker exec "$DA_CONTAINER" ps -eo pid,ppid,stat,etime,%cpu,%mem,rss,command \
             > "$artifact_dir/runtime-processes.txt"
+          worker_pid=$(docker exec "$DA_CONTAINER" bash -lc \
+            "ps -eo pid,%cpu,args --sort=-%cpu | awk '\$0 ~ /celery/ && \$0 !~ /awk/ {print \$1; exit}'")
+          if [ -n "$worker_pid" ]; then
+            docker exec "$DA_CONTAINER" bash -lc \
+              "pyspy_bin=\$(find /usr/share/docassemble -maxdepth 3 -path '*/local3.*/bin/py-spy' -print -quit); test -n \"\$pyspy_bin\"; timeout 30s \"\$pyspy_bin\" dump --native --pid '$worker_pid'" \
+              > "$artifact_dir/worker-stack.txt" 2>&1 || true
+          fi
 
       - name: Capture Docassemble logs on failure
         if: failure() || steps.crawl.outcome == 'failure'

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Install disposable runtime profiler
         run: |
           docker exec "$DA_CONTAINER" bash -lc \
-            'python_bin=$(find /usr/share/docassemble -maxdepth 3 -path "*/local3.*/bin/python" -print -quit); test -n "$python_bin"; "$python_bin" -m pip install py-spy==0.4.1'
+            'python_bin=$(find /usr/share/docassemble -maxdepth 3 -path "*/local3.*/bin/python" -print -quit); test -n "$python_bin"; "$python_bin" -m pip install py-spy==0.4.2'
 
       - name: Run every modeled path
         id: crawl

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -96,7 +96,7 @@ jobs:
             --env DA_ADMIN_API_KEY="$da_key" \
             --cap-add SYS_PTRACE \
             --memory 4gb \
-            --stop-timeout 600 \
+            --stop-timeout 60 \
             -d -p 80:80 \
             "$DA_IMAGE"
 
@@ -194,4 +194,4 @@ jobs:
 
       - name: Stop disposable server
         if: always()
-        run: docker stop -t 600 "$DA_CONTAINER" || true
+        run: docker stop -t 60 "$DA_CONTAINER" || true

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -2,6 +2,11 @@ name: Certify combined interview paths
 
 on:
   workflow_dispatch:
+    inputs:
+      scenario_pattern:
+        description: Full-match regex for modeled scenario names; leave blank for all paths
+        required: false
+        default: ''
   push:
     branches:
       - codex/exhaustive-path-certification
@@ -96,7 +101,7 @@ jobs:
             --env DA_ADMIN_PASSWORD="$da_password" \
             --env DA_ADMIN_API_KEY="$da_key" \
             --cap-add SYS_PTRACE \
-            --memory 4gb \
+            --memory 6gb \
             --stop-timeout 60 \
             -d -p 80:80 \
             "$DA_IMAGE"
@@ -161,12 +166,14 @@ jobs:
         working-directory: docassemble-MATC1ADivorceJointPetition
         env:
           DA_SERVER_URL: http://localhost
+          CERT_SCENARIO_PATTERN: ${{ inputs.scenario_pattern || '' }}
         run: |
           python tests/certification/generate_scenarios.py \
             --output tests/certification/artifacts/generated-scenarios
           python tests/certification/runtime_driver.py \
             --scenarios tests/certification/artifacts/generated-scenarios \
-            --ledger tests/certification/artifacts/runtime-ledger.json
+            --ledger tests/certification/artifacts/runtime-ledger.json \
+            ${CERT_SCENARIO_PATTERN:+--scenario-pattern "$CERT_SCENARIO_PATTERN"}
 
       - name: Audit complete screen and path coverage
         if: always()

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -183,9 +183,8 @@ jobs:
           mkdir -p docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
           docker logs "$DA_CONTAINER" --tail 500 \
             > docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docker.log 2>&1
-          docker exec "$DA_CONTAINER" bash -lc \
-            'tail -500 /tmp/docassemble/log/docassemble.log 2>/dev/null || true' \
-            > docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docassemble.log 2>&1
+          docker cp "$DA_CONTAINER:/usr/share/docassemble/log" \
+            docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docassemble-logs
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -1,0 +1,175 @@
+name: Certify combined interview paths
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - codex/exhaustive-path-certification
+    paths:
+      - '.github/workflows/certify-combined-interview.yml'
+      - 'docassemble/**'
+      - 'setup.py'
+      - 'tests/certification/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: combined-interview-certification-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DA_ADMIN_EMAIL: admin@example.com
+  DA_CONTAINER: combined-interview-certification
+  DA_IMAGE: jhpyle/docassemble@sha256:c0b0a707a6cd2149d5777ee83af1ea1de544210e597371eac93e67a1503c395c
+
+jobs:
+  static-model:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: docassemble-MATC1ADivorceJointPetition
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check out pinned local interview packages
+        working-directory: ${{ github.workspace }}
+        run: |
+          python docassemble-MATC1ADivorceJointPetition/tests/certification/checkout_packages.py \
+            --workspace "$GITHUB_WORKSPACE" \
+            --skip docassemble.MATC1ADivorceJointPetition
+
+      - name: Build static catalog and run harness tests
+        working-directory: docassemble-MATC1ADivorceJointPetition
+        run: |
+          python -m pip install pyyaml requests
+          python tests/certification/build_catalog.py --workspace "$GITHUB_WORKSPACE"
+          python -m unittest discover -s tests/certification -p 'test_*.py' -v
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: combined-static-catalog
+          path: docassemble-MATC1ADivorceJointPetition/tests/certification/static_catalog.json
+
+  runtime-baseline:
+    runs-on: ubuntu-latest
+    needs: static-model
+    timeout-minutes: 55
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: docassemble-MATC1ADivorceJointPetition
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test client dependencies
+        run: python -m pip install requests pyyaml docassemblecli
+
+      - name: Check out pinned local interview packages
+        working-directory: ${{ github.workspace }}
+        run: |
+          python docassemble-MATC1ADivorceJointPetition/tests/certification/checkout_packages.py \
+            --workspace "$GITHUB_WORKSPACE" \
+            --skip docassemble.MATC1ADivorceJointPetition
+
+      - name: Start disposable Docassemble server
+        run: |
+          da_key=$(openssl rand -hex 16)
+          da_password=$(openssl rand -base64 24)
+          echo "::add-mask::$da_key"
+          echo "::add-mask::$da_password"
+          echo "DA_API_KEY=$da_key" >> "$GITHUB_ENV"
+          docker pull "$DA_IMAGE"
+          docker run --name "$DA_CONTAINER" \
+            --env DA_ADMIN_EMAIL="$DA_ADMIN_EMAIL" \
+            --env DA_ADMIN_PASSWORD="$da_password" \
+            --env DA_ADMIN_API_KEY="$da_key" \
+            --cap-add SYS_PTRACE \
+            --memory 4gb \
+            --stop-timeout 600 \
+            -d -p 80:80 \
+            "$DA_IMAGE"
+
+      - name: Wait for initial readiness
+        run: |
+          for attempt in $(seq 1 30); do
+            status=$(curl -o /dev/null -s -w '%{http_code}' 'http://localhost/health_check?ready=1' || true)
+            if [ "$status" = 200 ]; then
+              exit 0
+            fi
+            sleep 20
+          done
+          docker logs "$DA_CONTAINER" --tail 200
+          exit 1
+
+      - name: Install pinned packages and current combined package
+        run: |
+          wait_ready() {
+            for attempt in $(seq 1 30); do
+              status=$(curl -o /dev/null -s -w '%{http_code}' 'http://localhost/health_check?ready=1' || true)
+              if [ "$status" = 200 ]; then
+                return 0
+              fi
+              sleep 10
+            done
+            return 1
+          }
+
+          for package_dir in \
+            docassemble-MATCMotionToAmend \
+            docassemble-MATCFinancialStatement \
+            docassemble-MATCSeparationAgreement \
+            docassemble-MATCChildCareOrCustodyDisclosureAffidavit \
+            docassemble-MATCCSGWorksheet \
+            docassemble-MATCFindingsAndDeterminations \
+            docassemble-MATC1ADivorceJointPetition; do
+            echo "::group::Install $package_dir"
+            wait_ready
+            timeout 10m dainstall "$GITHUB_WORKSPACE/$package_dir" \
+              --apiurl http://localhost \
+              --apikey "$DA_API_KEY"
+            echo "::endgroup::"
+          done
+          wait_ready
+
+      - name: Record runtime package and image manifest
+        run: |
+          mkdir -p docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
+          docker image inspect "$DA_IMAGE" --format '{{json .RepoDigests}}' \
+            > docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docker-image.json
+          docker exec "$DA_CONTAINER" bash -lc \
+            'python_bin=$(find /usr/share/docassemble -maxdepth 3 -path "*/local3.*/bin/python" -print -quit); test -n "$python_bin"; "$python_bin" -m pip freeze' \
+            > docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/pip-freeze.txt
+
+      - name: Run modeled baseline path
+        working-directory: docassemble-MATC1ADivorceJointPetition
+        env:
+          DA_SERVER_URL: http://localhost
+        run: |
+          python tests/certification/runtime_driver.py \
+            --ledger tests/certification/artifacts/runtime-ledger.json
+
+      - name: Capture Docassemble logs on failure
+        if: failure()
+        run: |
+          mkdir -p docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
+          docker logs "$DA_CONTAINER" --tail 500 \
+            > docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docker.log 2>&1
+          docker exec "$DA_CONTAINER" bash -lc \
+            'tail -500 /tmp/docassemble/log/docassemble.log 2>/dev/null || true' \
+            > docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docassemble.log 2>&1
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: combined-runtime-baseline
+          path: docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/
+
+      - name: Stop disposable server
+        if: always()
+        run: docker stop -t 600 "$DA_CONTAINER" || true

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -184,6 +184,15 @@ jobs:
             --ledger tests/certification/artifacts/runtime-ledger.json \
             --output tests/certification/artifacts/coverage-audit.json
 
+      - name: Capture runtime resource diagnostics
+        if: always()
+        continue-on-error: true
+        run: |
+          artifact_dir=docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
+          docker stats --no-stream "$DA_CONTAINER" > "$artifact_dir/docker-stats.txt"
+          docker exec "$DA_CONTAINER" ps -eo pid,ppid,stat,etime,%cpu,%mem,rss,command \
+            > "$artifact_dir/runtime-processes.txt"
+
       - name: Capture Docassemble logs on failure
         if: failure() || steps.crawl.outcome == 'failure'
         run: |

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -7,14 +7,6 @@ on:
         description: Full-match regex for modeled scenario names; leave blank for all paths
         required: false
         default: ''
-  push:
-    branches:
-      - codex/exhaustive-path-certification
-    paths:
-      - '.github/workflows/certify-combined-interview.yml'
-      - 'docassemble/**'
-      - 'setup.py'
-      - 'tests/certification/**'
 
 permissions:
   contents: read

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -54,10 +54,10 @@ jobs:
           name: combined-static-catalog
           path: docassemble-MATC1ADivorceJointPetition/tests/certification/static_catalog.json
 
-  runtime-baseline:
+  runtime-all-paths:
     runs-on: ubuntu-latest
     needs: static-model
-    timeout-minutes: 55
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,6 +76,11 @@ jobs:
           python docassemble-MATC1ADivorceJointPetition/tests/certification/checkout_packages.py \
             --workspace "$GITHUB_WORKSPACE" \
             --skip docassemble.MATC1ADivorceJointPetition
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: combined-static-catalog
+          path: docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
 
       - name: Start disposable Docassemble server
         run: |
@@ -149,16 +154,30 @@ jobs:
             --image docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docker-image.json \
             --pip-freeze docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/pip-freeze.txt
 
-      - name: Run modeled baseline path
+      - name: Run every modeled path
+        id: crawl
+        continue-on-error: true
         working-directory: docassemble-MATC1ADivorceJointPetition
         env:
           DA_SERVER_URL: http://localhost
         run: |
+          python tests/certification/generate_scenarios.py \
+            --output tests/certification/artifacts/generated-scenarios
           python tests/certification/runtime_driver.py \
+            --scenarios tests/certification/artifacts/generated-scenarios \
             --ledger tests/certification/artifacts/runtime-ledger.json
 
+      - name: Audit complete screen and path coverage
+        if: always()
+        working-directory: docassemble-MATC1ADivorceJointPetition
+        run: |
+          python tests/certification/audit_coverage.py \
+            --catalog tests/certification/artifacts/static_catalog.json \
+            --ledger tests/certification/artifacts/runtime-ledger.json \
+            --output tests/certification/artifacts/coverage-audit.json
+
       - name: Capture Docassemble logs on failure
-        if: failure()
+        if: failure() || steps.crawl.outcome == 'failure'
         run: |
           mkdir -p docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts
           docker logs "$DA_CONTAINER" --tail 500 \
@@ -170,7 +189,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: combined-runtime-baseline
+          name: combined-runtime-all-paths
           path: docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/
 
       - name: Stop disposable server

--- a/.github/workflows/certify-combined-interview.yml
+++ b/.github/workflows/certify-combined-interview.yml
@@ -145,6 +145,9 @@ jobs:
           docker exec "$DA_CONTAINER" bash -lc \
             'python_bin=$(find /usr/share/docassemble -maxdepth 3 -path "*/local3.*/bin/python" -print -quit); test -n "$python_bin"; "$python_bin" -m pip freeze' \
             > docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/pip-freeze.txt
+          python docassemble-MATC1ADivorceJointPetition/tests/certification/verify_runtime_manifest.py \
+            --image docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/docker-image.json \
+            --pip-freeze docassemble-MATC1ADivorceJointPetition/tests/certification/artifacts/pip-freeze.txt
 
       - name: Run modeled baseline path
         working-directory: docassemble-MATC1ADivorceJointPetition

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ en
 .flake8
 *.swp
 .DS_Store
+.github-actions-artifacts/
+tests/certification/artifacts/
+tests/certification/runtime_ledger.json
+tests/certification/static_catalog.json
+tests/certification/generated_scenarios/
+tests/certification/coverage_audit.json
 .envrc
 .env
 .venv

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -1467,8 +1467,8 @@ attachment:
       - "marriage_breakdown_date": ${ marriage_breakdown_date.format() }
       - "request_divorce_nofault": ${ request_divorce_nofault }
       - "request_separation_agreement_approval": ${ request_separation_agreement_approval }
-      - "request_merge_agreement": ${ request_merge_agreement }
-      - "request_survive_agreement": ${ request_survive_agreement }
+      - "request_merge_agreement": ${ petition_request_merge_agreement }
+      - "request_survive_agreement": ${ petition_request_survive_agreement }
       - "users1_request_name_change": ${ users1_request_name_change }
       - "users1_former_name_last": ${ users1_former_name_last }
       - "users2_request_name_change": ${ users2_request_name_change }

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -127,6 +127,10 @@ code: |
   
   nav.set_section("children_information")
   if children_of_marriage:
+    # The combined interview asks for an exact count before gathering. Set the
+    # list target here, where gather() consumes it, so included standalone
+    # list-collection rules cannot fall back to a one-at-a-time loop.
+    children.target_number = children_of_marriage_number
     children.gather()
     set_parts(subtitle=str(children))
     users1_number_of_custodial_children

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/divorce_joint_petition.yml
@@ -130,6 +130,7 @@ code: |
     # The combined interview asks for an exact count before gathering. Set the
     # list target here, where gather() consumes it, so included standalone
     # list-collection rules cannot fall back to a one-at-a-time loop.
+    children.ask_number = True
     children.target_number = children_of_marriage_number
     children.gather()
     set_parts(subtitle=str(children))

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -741,6 +741,7 @@ code: |
   divorcejointpetition_preview_question
   basic_questions_signature_flow
 
+  combined_bundle_final_packet_normalized
   combined_bundle_enabled_document_names
   if not defined("divorcejointpetition_downloads_ready"):
     if al_user_bundle.generate_downloads_with_docx_task.ready():
@@ -751,11 +752,11 @@ code: |
   combined_bundle_download_evidence
   divorcejointpetition_download
 ---
-id: combined bundle enabled document names
+id: combined bundle final packet normalization
 code: |
   # Included standalone packages can populate ALDocument enablement caches
-  # after the parent's initial normalization. Invalidate conditional packet
-  # state at the final enumeration point so this route's .enabled rules win.
+  # after the parent's initial normalization. Invalidate that state once,
+  # immediately before final enumeration, so this route's .enabled rules win.
   for conditional_document in (
       motion_to_amend_attachment,
       r408_attachment,
@@ -778,6 +779,10 @@ code: |
     conditional_document.always_enabled = False
     if hasattr(conditional_document.cache, "enabled"):
       del conditional_document.cache.enabled
+  combined_bundle_final_packet_normalized = True
+---
+id: combined bundle enabled document names
+code: |
   combined_bundle_enabled_document_names = [
     document.instanceName
     for document in al_user_bundle.enabled_documents(refresh=True)

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -449,11 +449,8 @@ code: |
     if has_children:
       children.target_number = len(children)
     interview_order_a_divorce_agreement
-    request_merge_agreement = (
-      children_of_marriage or not provisions_that_merge.all_false()
-    )
-    request_survive_agreement = True
-    set_petition_merger_survival_from_agreement = True
+
+  set_petition_merger_survival_values
 
   # Findings and Determinations (CJD 305) is only needed when the parties
   # deviate from the child support guidelines amount. Waiving support is a
@@ -482,6 +479,17 @@ code: |
     ask_affidavit_questions
 
   joint_petition_interview_order = True
+---
+code: |
+  if separation_agreement_format == "interview":
+    petition_request_merge_agreement = (
+      children_of_marriage or not provisions_that_merge.all_false()
+    )
+    petition_request_survive_agreement = True
+  else:
+    petition_request_merge_agreement = request_merge_agreement
+    petition_request_survive_agreement = request_survive_agreement
+  set_petition_merger_survival_values = True
 ---
 comment: |
   Search only the venue address worked out in divorce_joint_petition.yml.

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -746,7 +746,7 @@ code: |
     else:
       al_download_waiting_screen
 
-  combined_bundle_downloadable_files
+  combined_bundle_download_evidence
   divorcejointpetition_download
 ---
 id: combined bundle enabled document names
@@ -756,9 +756,33 @@ code: |
     for document in al_user_bundle.enabled_documents(refresh=True)
   ]
 ---
-id: combined bundle downloadable files
+id: combined bundle download evidence
 code: |
-  # Expose the completed background result through a public variable name.
-  # Docassemble intentionally rejects private attributes such as
-  # ``al_user_bundle._downloadable_files`` when passed to value().
-  combined_bundle_downloadable_files = al_user_bundle._downloadable_files
+  # Convert the completed background result into primitives before the
+  # certification API reads it.  DAFile objects cannot safely be serialized
+  # through value() and attempting to do so can fail the live interview.
+  combined_bundle_download_evidence = {"documents": [], "bundle_files": []}
+  certification_document_results, certification_zip, certification_pdf = al_user_bundle._downloadable_files
+  for certification_document in certification_document_results:
+    certification_document_evidence = {
+      "title": str(certification_document.get("title", "")),
+      "files": [],
+    }
+    for certification_format in ("pdf", "docx", "original"):
+      if certification_format in certification_document:
+        certification_file = certification_document[certification_format]
+        certification_document_evidence["files"].append({
+          "format": certification_format,
+          "filename": certification_file.filename,
+          "extension": certification_file.extension,
+          "ok": certification_file.ok,
+        })
+    combined_bundle_download_evidence["documents"].append(certification_document_evidence)
+  for certification_format, certification_file in (("zip", certification_zip), ("pdf", certification_pdf)):
+    if certification_file is not None:
+      combined_bundle_download_evidence["bundle_files"].append({
+        "format": certification_format,
+        "filename": certification_file.filename,
+        "extension": certification_file.extension,
+        "ok": certification_file.ok,
+      })

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -449,7 +449,11 @@ code: |
     if has_children:
       children.target_number = len(children)
     interview_order_a_divorce_agreement
-    set_petition_merger_survival_from_agreement
+    request_merge_agreement = (
+      children_of_marriage or not provisions_that_merge.all_false()
+    )
+    request_survive_agreement = True
+    set_petition_merger_survival_from_agreement = True
 
   # Findings and Determinations (CJD 305) is only needed when the parties
   # deviate from the child support guidelines amount. Waiving support is a
@@ -478,16 +482,6 @@ code: |
     ask_affidavit_questions
 
   joint_petition_interview_order = True
----
-depends on:
-  - children_of_marriage
-  - provisions_that_merge
-code: |
-  request_merge_agreement = (
-    children_of_marriage or not provisions_that_merge.all_false()
-  )
-  request_survive_agreement = True
-  set_petition_merger_survival_from_agreement = True
 ---
 comment: |
   Search only the venue address worked out in divorce_joint_petition.yml.

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -480,11 +480,11 @@ code: |
   joint_petition_interview_order = True
 ---
 depends on:
-  - has_children
+  - children_of_marriage
   - provisions_that_merge
 code: |
   request_merge_agreement = (
-    has_children or not provisions_that_merge.all_false()
+    children_of_marriage or not provisions_that_merge.all_false()
   )
   request_survive_agreement = True
   set_petition_merger_survival_from_agreement = True

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -336,6 +336,20 @@ code: |
       )
     else:
       certification_snapshot[variable_name] = 0
+  certification_snapshot["uploaded_files"] = {}
+  for variable_name in action_argument("files") or []:
+    certification_file_list = value(variable_name)
+    certification_file = certification_file_list[0]
+    # path() performs the same SavedFile retrieval that Docassemble's PDF
+    # preview worker needs. A missing database/file-store record therefore
+    # fails this action instead of letting an upload route pass on metadata.
+    certification_file.path()
+    certification_snapshot["uploaded_files"][variable_name] = {
+      "retrievable": bool(certification_file.ok),
+      "filename": certification_file.filename,
+      "extension": certification_file.extension,
+      "mimetype": certification_file.mimetype,
+    }
   json_response(certification_snapshot)
 ---
 code: |
@@ -536,6 +550,11 @@ code: |
   ask_if_qualifies_for_fee_waiver
   if ask_if_qualifies_for_fee_waiver:
     ask_affidavit_questions
+    if not is_indigent:
+      # The standalone affidavit wrapper explains this outcome, but the
+      # combined parent includes only affidavit_body.yml. Do not silently
+      # return to the divorce packet when the user does not qualify.
+      doesnt_qualify_interstitial
 
   joint_petition_interview_order = True
 ---

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -753,6 +753,31 @@ code: |
 ---
 id: combined bundle enabled document names
 code: |
+  # Included standalone packages can populate ALDocument enablement caches
+  # after the parent's initial normalization. Invalidate conditional packet
+  # state at the final enumeration point so this route's .enabled rules win.
+  for conditional_document in (
+      motion_to_amend_attachment,
+      r408_attachment,
+      affidavitofindigency_attachment,
+      child_care_or_custody_disclosure_affidavit_next_steps,
+      affidavit_of_care_or_custody_attachment,
+      ma_child_support_guidelines_worksheet_attachment,
+      cjd_305_attachment,
+      users[0].financial_statement_short_attachment,
+      users[0].financial_statement_long_attachment,
+      users[0].financial_statement_schedule_a_attachment,
+      users[0].financial_statement_schedule_b_attachment,
+      users[1].financial_statement_short_attachment,
+      users[1].financial_statement_long_attachment,
+      users[1].financial_statement_schedule_a_attachment,
+      users[1].financial_statement_schedule_b_attachment,
+      a_divorce_agreement_Post_interview_instructions,
+      a_divorce_agreement_attachment,
+  ):
+    conditional_document.always_enabled = False
+    if hasattr(conditional_document.cache, "enabled"):
+      del conditional_document.cache.enabled
   combined_bundle_enabled_document_names = [
     document.instanceName
     for document in al_user_bundle.enabled_documents(refresh=True)

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -491,6 +491,20 @@ code: |
     petition_request_survive_agreement = request_survive_agreement
   set_petition_merger_survival_values = True
 ---
+# The care-or-custody package also ships a standalone list-collect definition
+# for children[i].name.first. In the combined interview, the spouses already
+# chose an exact child count and children.target_number is set from it. Keep a
+# parent-owned definition here so the standalone 16-row collector cannot
+# replace the fixed-count child loop.
+id: combined child details
+question: |
+  Information about your ${ ordinal(i) } child
+fields:
+  - code: |
+      children[i].name_fields()
+  - Birthdate: children[i].birthdate
+    datatype: date
+---
 comment: |
   Search only the venue address worked out in divorce_joint_petition.yml.
   This lives in the top-level file on purpose: it is loaded after every

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -394,7 +394,7 @@ code: |
   nav.set_section("convert_1b_to_1a")
   has_existing_1b_action
   if has_existing_1b_action:
-    interview_order_motion_to_amend
+    combined_interview_order_motion_to_amend
 
   nav.set_section("packet_options")
   include_financial_statement
@@ -479,6 +479,78 @@ code: |
     ask_affidavit_questions
 
   joint_petition_interview_order = True
+---
+comment: |
+  The standalone motion interview swaps users.elements when the original 1B
+  plaintiff should be Party B. Moving ALIndividual objects between DAList
+  indices leaves their instance names pointing at the old indices and caused a
+  certified al_court_bundle assembly cycle. In the combined interview the
+  parent owns this integration order. Swap only the already-collected name
+  values, before collecting every remaining party attribute, so each object
+  keeps its canonical users[0]/users[1] identity.
+id: combined interview order motion to amend
+code: |
+  allowed_courts = ['Probate and Family Court']
+  user_role = "plaintiff"
+  user_ask_role = "plaintiff"
+
+  users[0].name.first
+  users[1].name.first
+  plaintiff_is_party_a
+  if not plaintiff_is_party_a:
+    users[0].name.first, users[1].name.first = users[1].name.first, users[0].name.first
+    users[0].name.middle, users[1].name.middle = users[1].name.middle, users[0].name.middle
+    users[0].name.last, users[1].name.last = users[1].name.last, users[0].name.last
+    users[0].name.suffix, users[1].name.suffix = users[1].name.suffix, users[0].name.suffix
+    plaintiff_index = 1
+  else:
+    plaintiff_index = 0
+  defendant_index = 1 - plaintiff_index
+
+  trial_court.division
+  docket_number
+  set_progress(30)
+  marriage_breakdown_date
+  breakdown_location
+  action_commenced_date
+  set_progress(50)
+
+  users[0].has_attorney
+  if users[0].has_attorney:
+    attorneys[0].name_fields()
+    attorneys[0].address_fields()
+    attorneys[0].phone_number
+    attorneys[0].bbo_number
+  else:
+    users[0].phone_number
+
+  set_progress(70)
+  users[1].has_attorney
+  if users[1].has_attorney:
+    attorneys[1].name_fields()
+    attorneys[1].address_fields()
+    attorneys[1].phone_number
+    attorneys[1].bbo_number
+  else:
+    users[1].phone_number
+
+  set_progress(90)
+  if plaintiff_index == 0:
+    if not users[0].has_attorney:
+      users[0].signature
+    if not users[1].has_attorney:
+      users[1].signature
+    else:
+      attorneys[1].signature
+  else:
+    if not users[1].has_attorney:
+      users[1].signature
+    if not users[0].has_attorney:
+      users[0].signature
+    else:
+      attorneys[0].signature
+
+  combined_interview_order_motion_to_amend = True
 ---
 code: |
   if separation_agreement_format == "interview":

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -764,6 +764,14 @@ code: |
       },
   )
   divorcejointpetition_preview_question
+  # Several included child interviews define the global signature_fields
+  # variable. Set the combined packet's signer matrix at the point of use so
+  # a child's standalone default cannot make represented spouses sign instead
+  # of their attorneys.
+  signature_fields = [
+      'attorneys[0].signature' if users[0].has_attorney else 'users[0].signature',
+      'attorneys[1].signature' if users[1].has_attorney else 'users[1].signature',
+  ]
   basic_questions_signature_flow
 
   combined_bundle_final_packet_normalized

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -313,7 +313,7 @@ code: |
 # every ALDocument in the session and can itself generate unrelated previews.
 # Return only the requested values and plain collection counts so observation
 # cannot change packet membership or exhaust the runtime under test.
-event: combined certification snapshot
+event: combined_certification_snapshot
 code: |
   certification_snapshot = {}
   for variable_name in action_argument("values") or []:

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -500,7 +500,7 @@ code: |
     # The parent interview has already collected this shared child information.
     has_children = children_of_marriage
     if has_children:
-      children.target_number = len(children)
+      children.target_number = children_of_marriage_number
     interview_order_a_divorce_agreement
 
   set_petition_merger_survival_values
@@ -755,30 +755,85 @@ code: |
 id: combined bundle final packet normalization
 code: |
   # Included standalone packages can populate ALDocument enablement caches
-  # after the parent's initial normalization. Invalidate that state once,
-  # immediately before final enumeration, so this route's .enabled rules win.
-  for conditional_document in (
-      motion_to_amend_attachment,
-      r408_attachment,
-      affidavitofindigency_attachment,
-      child_care_or_custody_disclosure_affidavit_next_steps,
-      affidavit_of_care_or_custody_attachment,
-      ma_child_support_guidelines_worksheet_attachment,
-      cjd_305_attachment,
-      users[0].financial_statement_short_attachment,
-      users[0].financial_statement_long_attachment,
-      users[0].financial_statement_schedule_a_attachment,
-      users[0].financial_statement_schedule_b_attachment,
-      users[1].financial_statement_short_attachment,
-      users[1].financial_statement_long_attachment,
-      users[1].financial_statement_schedule_a_attachment,
-      users[1].financial_statement_schedule_b_attachment,
-      a_divorce_agreement_Post_interview_instructions,
-      a_divorce_agreement_attachment,
+  # after the parent's initial normalization. Pin the final route decisions in
+  # the cache immediately before enumeration. Merely deleting these values can
+  # re-run an included package's ALDocument constructor with enabled=True.
+  for conditional_document, final_enabled in (
+      (motion_to_amend_attachment, has_existing_1b_action),
+      (r408_attachment, include_r408),
+      (
+        affidavitofindigency_attachment,
+        ask_if_qualifies_for_fee_waiver and is_indigent,
+      ),
+      (
+        child_care_or_custody_disclosure_affidavit_next_steps,
+        include_care_or_custody_affidavit,
+      ),
+      (
+        affidavit_of_care_or_custody_attachment,
+        include_care_or_custody_affidavit,
+      ),
+      (
+        ma_child_support_guidelines_worksheet_attachment,
+        include_child_support_guidelines_worksheet,
+      ),
+      (cjd_305_attachment, include_findings_and_determinations),
+      (
+        users[0].financial_statement_short_attachment,
+        include_financial_statement
+        and showifdef(users[0].attr_name("making_statement_for"))
+        and showifdef(users[0].attr_name("financial_form_type")) == "short",
+      ),
+      (
+        users[0].financial_statement_long_attachment,
+        include_financial_statement
+        and showifdef(users[0].attr_name("making_statement_for"))
+        and showifdef(users[0].attr_name("financial_form_type")) == "long",
+      ),
+      (
+        users[0].financial_statement_schedule_a_attachment,
+        include_financial_statement
+        and showifdef(users[0].attr_name("making_statement_for"))
+        and showifdef(users[0].attr_name("has_self_employment_income")),
+      ),
+      (
+        users[0].financial_statement_schedule_b_attachment,
+        include_financial_statement
+        and showifdef(users[0].attr_name("making_statement_for"))
+        and showifdef(users[0].attr_name("has_rental_income")),
+      ),
+      (
+        users[1].financial_statement_short_attachment,
+        include_financial_statement
+        and showifdef(users[1].attr_name("making_statement_for"))
+        and showifdef(users[1].attr_name("financial_form_type")) == "short",
+      ),
+      (
+        users[1].financial_statement_long_attachment,
+        include_financial_statement
+        and showifdef(users[1].attr_name("making_statement_for"))
+        and showifdef(users[1].attr_name("financial_form_type")) == "long",
+      ),
+      (
+        users[1].financial_statement_schedule_a_attachment,
+        include_financial_statement
+        and showifdef(users[1].attr_name("making_statement_for"))
+        and showifdef(users[1].attr_name("has_self_employment_income")),
+      ),
+      (
+        users[1].financial_statement_schedule_b_attachment,
+        include_financial_statement
+        and showifdef(users[1].attr_name("making_statement_for"))
+        and showifdef(users[1].attr_name("has_rental_income")),
+      ),
+      (
+        a_divorce_agreement_Post_interview_instructions,
+        include_separation_agreement,
+      ),
+      (a_divorce_agreement_attachment, include_separation_agreement),
   ):
     conditional_document.always_enabled = False
-    if hasattr(conditional_document.cache, "enabled"):
-      del conditional_document.cache.enabled
+    conditional_document.cache.enabled = bool(final_enabled)
   combined_bundle_final_packet_normalized = True
 ---
 id: combined bundle enabled document names

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -500,6 +500,7 @@ code: |
     # The parent interview has already collected this shared child information.
     has_children = children_of_marriage
     if has_children:
+      children.ask_number = True
       children.target_number = children_of_marriage_number
     interview_order_a_divorce_agreement
 
@@ -833,6 +834,7 @@ code: |
       (a_divorce_agreement_attachment, include_separation_agreement),
   ):
     conditional_document.always_enabled = False
+    conditional_document.enabled = bool(final_enabled)
     conditional_document.cache.enabled = bool(final_enabled)
   combined_bundle_final_packet_normalized = True
 ---

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -308,6 +308,29 @@ code: |
   divorcejointpetition_downloads_ready = True
   background_response()
 ---
+# The certification client uses this authenticated, read-only action instead
+# of GET /api/session. Serializing the complete interview dictionary traverses
+# every ALDocument in the session and can itself generate unrelated previews.
+# Return only the requested values and plain collection counts so observation
+# cannot change packet membership or exhaust the runtime under test.
+event: combined certification snapshot
+code: |
+  certification_snapshot = {}
+  for variable_name in action_argument("values") or []:
+    if defined(variable_name):
+      certification_snapshot[variable_name] = value(variable_name)
+  for variable_name in action_argument("counts") or []:
+    if defined(variable_name):
+      certification_collection = value(variable_name)
+      certification_snapshot[variable_name] = len(
+        certification_collection.elements
+        if hasattr(certification_collection, "elements")
+        else certification_collection
+      )
+    else:
+      certification_snapshot[variable_name] = 0
+  json_response(certification_snapshot)
+---
 code: |
   enable_al_nav_sections = True
 ---
@@ -716,6 +739,7 @@ code: |
   divorcejointpetition_preview_question
   basic_questions_signature_flow
 
+  combined_bundle_enabled_document_names
   if not defined("divorcejointpetition_downloads_ready"):
     if al_user_bundle.generate_downloads_with_docx_task.ready():
       divorcejointpetition_downloads_ready = True
@@ -723,3 +747,10 @@ code: |
       al_download_waiting_screen
 
   divorcejointpetition_download
+---
+id: combined bundle enabled document names
+code: |
+  combined_bundle_enabled_document_names = [
+    document.instanceName
+    for document in al_user_bundle.enabled_documents(refresh=True)
+  ]

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -746,6 +746,7 @@ code: |
     else:
       al_download_waiting_screen
 
+  combined_bundle_downloadable_files
   divorcejointpetition_download
 ---
 id: combined bundle enabled document names
@@ -754,3 +755,10 @@ code: |
     document.instanceName
     for document in al_user_bundle.enabled_documents(refresh=True)
   ]
+---
+id: combined bundle downloadable files
+code: |
+  # Expose the completed background result through a public variable name.
+  # Docassemble intentionally rejects private attributes such as
+  # ``al_user_bundle._downloadable_files`` when passed to value().
+  combined_bundle_downloadable_files = al_user_bundle._downloadable_files

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -320,7 +320,12 @@ code: |
   certification_snapshot = {}
   for variable_name in action_argument("values") or []:
     if defined(variable_name):
-      certification_snapshot[variable_name] = value(variable_name)
+      certification_value = value(variable_name)
+      certification_snapshot[variable_name] = (
+        certification_value.as_serializable()
+        if hasattr(certification_value, "as_serializable")
+        else certification_value
+      )
   for variable_name in action_argument("counts") or []:
     if defined(variable_name):
       certification_collection = value(variable_name)

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -569,6 +569,12 @@ code: |
 # parent-owned definition here so the standalone 16-row collector cannot
 # replace the fixed-count child loop.
 id: combined child details
+sets:
+  - children[i].name.first
+  - children[i].name.last
+  - children[i].name.middle
+  - children[i].name.suffix
+  - children[i].birthdate
 question: |
   Information about your ${ ordinal(i) } child
 fields:

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -182,6 +182,7 @@ code: |
 code: |
   for conditional_document in (
       motion_to_amend_attachment,
+      r408_attachment,
       affidavitofindigency_attachment,
       child_care_or_custody_disclosure_affidavit_next_steps,
       affidavit_of_care_or_custody_attachment,

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -200,6 +200,8 @@ code: |
       a_divorce_agreement_attachment,
   ):
     conditional_document.always_enabled = False
+    if hasattr(conditional_document.cache, "enabled"):
+      del conditional_document.cache.enabled
   combined_bundle_documents_normalized = True
 ---
 id: existing 1B action screener

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -750,7 +750,10 @@ code: |
   combined_bundle_final_packet_normalized
   combined_bundle_enabled_document_names
   if not defined("divorcejointpetition_downloads_ready"):
-    if al_user_bundle.generate_downloads_with_docx_task.ready():
+    if (
+        al_user_bundle.generate_downloads_with_docx_task.ready()
+        and defined("al_user_bundle._downloadable_files")
+    ):
       divorcejointpetition_downloads_ready = True
     else:
       al_download_waiting_screen

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/main_joint_petition.yml
@@ -175,6 +175,32 @@ code: |
   users[0].separation_agreement_role = "party_a"
   users[1].separation_agreement_role = "party_b"
 ---
+# Standalone child interviews initialize some documents with enabled=True,
+# which AssemblyLine preserves as always_enabled. The combined parent owns its
+# packet composition, so clear that standalone override before evaluating the
+# per-route .enabled definitions below.
+code: |
+  for conditional_document in (
+      motion_to_amend_attachment,
+      affidavitofindigency_attachment,
+      child_care_or_custody_disclosure_affidavit_next_steps,
+      affidavit_of_care_or_custody_attachment,
+      ma_child_support_guidelines_worksheet_attachment,
+      cjd_305_attachment,
+      users[0].financial_statement_short_attachment,
+      users[0].financial_statement_long_attachment,
+      users[0].financial_statement_schedule_a_attachment,
+      users[0].financial_statement_schedule_b_attachment,
+      users[1].financial_statement_short_attachment,
+      users[1].financial_statement_long_attachment,
+      users[1].financial_statement_schedule_a_attachment,
+      users[1].financial_statement_schedule_b_attachment,
+      a_divorce_agreement_Post_interview_instructions,
+      a_divorce_agreement_attachment,
+  ):
+    conditional_document.always_enabled = False
+  combined_bundle_documents_normalized = True
+---
 id: existing 1B action screener
 question: |
   Do you already have a divorce case filed?
@@ -391,6 +417,7 @@ content: |
 ---
 id: joint petition interview order
 code: |
+  combined_bundle_documents_normalized
   nav.set_section("convert_1b_to_1a")
   has_existing_1b_action
   if has_existing_1b_action:

--- a/docassemble/MATC1ADivorceJointPetition/data/questions/r408_report_of_absolute_divorce.yml
+++ b/docassemble/MATC1ADivorceJointPetition/data/questions/r408_report_of_absolute_divorce.yml
@@ -161,11 +161,17 @@ code: |
     users1_number_of_custodial_children = 0
     users2_number_of_custodial_children = 0
   if need_r408_demographics:
-    r408_demographics
+    users1_gender
+    users2_gender
+    users1_ssn_last_four
+    users2_ssn_last_four
   if need_r408_marriage_numbers:
-    r408_prior_marriages_and_birth_names
+    users1_marriage_number
+    users2_marriage_number
+    users1_name_last_at_birth
+    users2_name_last_at_birth
   if need_r408_addendum:
-    r408_additional_children_info
+    r408_addendum
   interview_order_r408 = True
 ---
 objects:

--- a/tests/certification/README.md
+++ b/tests/certification/README.md
@@ -14,15 +14,17 @@ of example runs.
   screens and branch expressions.
 - `generate_scenarios.py` materializes every declared path archetype.
 - `runtime_driver.py` drives fresh API sessions and writes every transition,
-  answer, terminal state, error, and timeout to a ledger.
+  answer, terminal state, generated bundle member, error, and timeout to a
+  ledger. Screens are keyed by package/file plus a fingerprint of the exact
+  YAML block, so reused IDs cannot satisfy each other.
 - `verify_runtime_manifest.py` rejects image or external-package drift before
   a runtime result can count.
-- `screen_classification.yml` is the only place a local screen may be excluded,
-  and every exclusion requires a source-backed reason.
+- `screen_classification.yml` is the only place an exact local screen block may
+  be excluded, and every exclusion requires a source-backed reason.
 - `audit_coverage.py` compares runtime evidence with the static denominator and
-  fails if any screen or distinguishable duplicate-ID variant is missing, an
-  exclusion is stale or unsupported, a modeled path is absent, a path fails,
-  or a path reaches the wrong terminal outcome.
+  fails if any exact source screen is missing, an exclusion is stale or
+  unsupported, a modeled path is absent, a path fails, a generated packet has
+  a missing or extra document, or a path reaches the wrong terminal outcome.
 
 Generated catalogs, scenarios, ledgers, logs, and runtime manifests are CI
 artifacts. They are intentionally not committed as hand-edited evidence.

--- a/tests/certification/README.md
+++ b/tests/certification/README.md
@@ -16,7 +16,9 @@ of example runs.
 - `runtime_driver.py` drives fresh API sessions and writes every transition,
   answer, terminal state, generated bundle member, error, and timeout to a
   ledger. Screens are keyed by package/file plus a fingerprint of the exact
-  YAML block, so reused IDs cannot satisfy each other.
+  YAML block, so reused IDs cannot satisfy each other. If Docassemble reports
+  an abbreviated source locator, the audit accepts it only when that exact
+  fingerprint has one unambiguous catalog match.
 - `verify_runtime_manifest.py` rejects image or external-package drift before
   a runtime result can count.
 - `screen_classification.yml` is the only place an exact local screen block may
@@ -56,4 +58,9 @@ python3 -m unittest discover -s tests/certification -p 'test_*.py' -v
 ```
 
 Runtime tests require a Docassemble server and API key. CI supplies both using
-an isolated Docker container.
+an isolated Docker container. Terminal assertions use the interview's
+authenticated, read-only `combined certification snapshot` action rather than
+`GET /api/session`: serializing the complete interview dictionary can traverse
+ALDocument objects and generate previews merely by observing them. Exact packet
+membership is proved from `enabled_documents()` immediately before generation,
+then corroborated against the background task's `_downloadable_files` results.

--- a/tests/certification/README.md
+++ b/tests/certification/README.md
@@ -64,3 +64,7 @@ authenticated, read-only `combined certification snapshot` action rather than
 ALDocument objects and generate previews merely by observing them. Exact packet
 membership is proved from `enabled_documents()` immediately before generation,
 then corroborated against the background task's `_downloadable_files` results.
+
+Manual workflow dispatches may set `scenario_pattern` to a full-match regular
+expression for focused diagnosis. A blank pattern remains the only exhaustive
+certification run; focused ledgers intentionally fail the all-path audit.

--- a/tests/certification/README.md
+++ b/tests/certification/README.md
@@ -25,8 +25,9 @@ of example runs.
   be excluded, and every exclusion requires a source-backed reason.
 - `audit_coverage.py` compares runtime evidence with the static denominator and
   fails if any exact source screen is missing, an exclusion is stale or
-  unsupported, a modeled path is absent, a path fails, a generated packet has
-  a missing or extra document, or a path reaches the wrong terminal outcome.
+  unsupported or contradicted by runtime observation, a modeled path is absent,
+  a path fails, a generated packet has a missing or extra document, or a path
+  reaches the wrong terminal outcome.
 
 Generated catalogs, scenarios, ledgers, logs, and runtime manifests are CI
 artifacts. They are intentionally not committed as hand-edited evidence.

--- a/tests/certification/README.md
+++ b/tests/certification/README.md
@@ -1,0 +1,51 @@
+# Combined interview certification
+
+This directory treats coverage as an auditable claim rather than a collection
+of example runs.
+
+## Proof artifacts
+
+- `baseline.json` pins the combined source, each local included package, and
+  known candidate overlays that have not yet been accepted.
+- `coverage_model.yml` declares the finite path model, input equivalence
+  classes, list cardinality boundaries, and hang thresholds.
+- `build_catalog.py` resolves the local include graph and catalogs declared
+  screens and branch expressions.
+- `generate_scenarios.py` materializes every declared path archetype.
+- `runtime_driver.py` drives fresh API sessions and writes every transition,
+  answer, terminal state, error, and timeout to a ledger.
+- `screen_classification.yml` is the only place a local screen may be excluded,
+  and every exclusion requires a source-backed reason.
+- `audit_coverage.py` compares runtime evidence with the static denominator and
+  fails if any screen is missing, an exclusion is stale or unsupported, or a
+  path failed.
+
+Generated catalogs, scenarios, ledgers, logs, and runtime manifests are CI
+artifacts. They are intentionally not committed as hand-edited evidence.
+
+## Hang definition
+
+A path fails when any one of these occurs:
+
+1. an HTTP request exceeds the declared request timeout;
+2. the same runtime state appears too many times consecutively;
+3. a state is revisited beyond the declared limit;
+4. a scenario exceeds its wall-clock budget;
+5. the interview exceeds its maximum step count; or
+6. Docassemble reports an infinite loop or another error screen.
+
+List questions include the sought variable and index in their state
+fingerprint, so legitimate repeated list screens are not mistaken for hangs.
+
+## Local static checks
+
+From the repository root:
+
+```bash
+python3 tests/certification/build_catalog.py
+python3 tests/certification/generate_scenarios.py
+python3 -m unittest discover -s tests/certification -p 'test_*.py' -v
+```
+
+Runtime tests require a Docassemble server and API key. CI supplies both using
+an isolated Docker container.

--- a/tests/certification/README.md
+++ b/tests/certification/README.md
@@ -59,7 +59,7 @@ python3 -m unittest discover -s tests/certification -p 'test_*.py' -v
 
 Runtime tests require a Docassemble server and API key. CI supplies both using
 an isolated Docker container. Terminal assertions use the interview's
-authenticated, read-only `combined certification snapshot` action rather than
+authenticated, read-only `combined_certification_snapshot` action rather than
 `GET /api/session`: serializing the complete interview dictionary can traverse
 ALDocument objects and generate previews merely by observing them. Exact packet
 membership is proved from `enabled_documents()` immediately before generation,

--- a/tests/certification/README.md
+++ b/tests/certification/README.md
@@ -6,7 +6,8 @@ of example runs.
 ## Proof artifacts
 
 - `baseline.json` pins the combined source, each local included package, and
-  known candidate overlays that have not yet been accepted.
+  known candidate overlays that have not yet been accepted. It also pins the
+  Docker image digest and external interview package versions.
 - `coverage_model.yml` declares the finite path model, input equivalence
   classes, list cardinality boundaries, and hang thresholds.
 - `build_catalog.py` resolves the local include graph and catalogs declared
@@ -14,11 +15,14 @@ of example runs.
 - `generate_scenarios.py` materializes every declared path archetype.
 - `runtime_driver.py` drives fresh API sessions and writes every transition,
   answer, terminal state, error, and timeout to a ledger.
+- `verify_runtime_manifest.py` rejects image or external-package drift before
+  a runtime result can count.
 - `screen_classification.yml` is the only place a local screen may be excluded,
   and every exclusion requires a source-backed reason.
 - `audit_coverage.py` compares runtime evidence with the static denominator and
-  fails if any screen is missing, an exclusion is stale or unsupported, or a
-  path failed.
+  fails if any screen or distinguishable duplicate-ID variant is missing, an
+  exclusion is stale or unsupported, a modeled path is absent, a path fails,
+  or a path reaches the wrong terminal outcome.
 
 Generated catalogs, scenarios, ledgers, logs, and runtime manifests are CI
 artifacts. They are intentionally not committed as hand-edited evidence.
@@ -31,8 +35,10 @@ A path fails when any one of these occurs:
 2. the same runtime state appears too many times consecutively;
 3. a state is revisited beyond the declared limit;
 4. a scenario exceeds its wall-clock budget;
-5. the interview exceeds its maximum step count; or
-6. Docassemble reports an infinite loop or another error screen.
+5. the interview exceeds its maximum step count;
+6. background document generation stays on AssemblyLine's waiting screen past
+   its separate task timeout; or
+7. Docassemble reports an infinite loop or another error screen.
 
 List questions include the sought variable and index in their state
 fingerprint, so legitimate repeated list screens are not mistaken for hangs.

--- a/tests/certification/audit_coverage.py
+++ b/tests/certification/audit_coverage.py
@@ -47,7 +47,6 @@ def audit(
     model: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     runtime_records = runtime_screen_records(ledger)
-    observed_coordinates = {screen_coordinate(record) for record in runtime_records}
     observed_ids = {
         str(record["id"])
         for record in runtime_records
@@ -65,6 +64,31 @@ def audit(
     ]
     feature_declared = {screen_coordinate(screen) for screen in feature_screens}
     framework_catalog = {screen_coordinate(screen) for screen in framework_screens}
+    catalog_coordinates = feature_declared | framework_catalog
+    catalog_by_fingerprint: dict[str, set[str]] = {}
+    for screen in catalog["screens"]:
+        fingerprint = screen.get("source_fingerprint")
+        if fingerprint:
+            catalog_by_fingerprint.setdefault(str(fingerprint), set()).add(
+                screen_coordinate(screen)
+            )
+
+    def resolved_runtime_coordinate(record: dict[str, Any]) -> str:
+        direct = screen_coordinate(record)
+        if direct in catalog_coordinates:
+            return direct
+        # Docassemble's debug API sometimes reports only a basename or omits
+        # ``data/questions`` for included files. The canonical YAML-document
+        # fingerprint still identifies the exact static block. Resolve only a
+        # unique match; duplicated blocks remain explicit audit failures.
+        candidates = catalog_by_fingerprint.get(
+            str(record.get("source_fingerprint") or ""), set()
+        )
+        return next(iter(candidates)) if len(candidates) == 1 else direct
+
+    observed_coordinates = {
+        resolved_runtime_coordinate(record) for record in runtime_records
+    }
     # Feature-package screens are exhaustive obligations. Framework packages
     # also contain generic saved-session, authoring, and standalone utility
     # screens that this interview never calls; any framework screen actually

--- a/tests/certification/audit_coverage.py
+++ b/tests/certification/audit_coverage.py
@@ -111,8 +111,11 @@ def audit(
         if result.get("status") != "pass":
             continue
         for name, evidence in result.get("cardinality_evidence", {}).items():
-            if isinstance(evidence.get("observed"), int):
-                observed_cardinality_classes.setdefault(name, set()).add(evidence["observed"])
+            observed_value = evidence.get("observed")
+            values = observed_value if isinstance(observed_value, list) else [observed_value]
+            for value in values:
+                if isinstance(value, int):
+                    observed_cardinality_classes.setdefault(name, set()).add(value)
     missing_cardinality_classes = {
         name: sorted(values - observed_cardinality_classes.get(name, set()))
         for name, values in expected_cardinality_classes.items()

--- a/tests/certification/audit_coverage.py
+++ b/tests/certification/audit_coverage.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Audit runtime evidence against the declared static and path models."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def normalized_variable(value: Any) -> str:
+    return re.sub(r"\[\d+\]", "[i]", str(value or ""))
+
+
+def static_variant_signature(screen: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        screen.get("event"),
+        normalized_variable(screen.get("continue_button_field")),
+        tuple(sorted(normalized_variable(value) for value in screen.get("sets") or [])),
+        tuple(sorted(normalized_variable(value) for value in screen.get("variables") or [])),
+    )
+
+
+def audit(
+    catalog: dict[str, Any],
+    ledger: dict[str, Any],
+    classifications: dict[str, Any],
+    model: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    declared = {screen["id"] for screen in catalog["screens"]}
+    observed = {
+        screen_id
+        for result in ledger.get("results", [])
+        for screen_id in result.get("seen_screen_ids", [])
+    }
+    static_variants: dict[str, set[tuple[Any, ...]]] = {}
+    for screen in catalog["screens"]:
+        static_variants.setdefault(screen["id"], set()).add(static_variant_signature(screen))
+    observed_variants: dict[str, set[str]] = {}
+    for result in ledger.get("results", []):
+        for step in result.get("steps", []):
+            if step.get("id") and step.get("variant_fingerprint"):
+                observed_variants.setdefault(step["id"], set()).add(step["variant_fingerprint"])
+    has_variant_evidence = bool(observed_variants)
+    missing_screen_variants = (
+        {
+            screen_id: {
+                "expected": len(signatures),
+                "observed": len(observed_variants.get(screen_id, set())),
+            }
+            for screen_id, signatures in static_variants.items()
+            if len(observed_variants.get(screen_id, set())) < len(signatures)
+            and screen_id in observed
+        }
+        if has_variant_evidence
+        else {}
+    )
+    exclusions = classifications.get("proven_unreachable", {})
+    excluded = set(exclusions)
+    missing = declared - observed - excluded
+    stale_exclusions = excluded - declared
+    failed_paths = [
+        {
+            "name": result.get("name"),
+            "failure": result.get("failure"),
+            "last_screen": (result.get("steps") or [{}])[-1].get("id"),
+        }
+        for result in ledger.get("results", [])
+        if result.get("status") != "pass"
+    ]
+    unsupported_exclusions = [
+        screen_id for screen_id, reason in exclusions.items() if not str(reason).strip()
+    ]
+    expected_paths = {path["name"] for path in (model or {}).get("modeled_paths", [])}
+    observed_paths = {result.get("name") for result in ledger.get("results", [])}
+    missing_paths = expected_paths - observed_paths
+    unexpected_paths = observed_paths - expected_paths if expected_paths else set()
+    passed = (
+        not missing
+        and not stale_exclusions
+        and not failed_paths
+        and not unsupported_exclusions
+        and not missing_paths
+        and not unexpected_paths
+        and not missing_screen_variants
+    )
+    return {
+        "passed": passed,
+        "declared_local_screen_ids": len(declared),
+        "observed_screen_ids": len(observed),
+        "observed_local_screen_ids": len(declared & observed),
+        "observed_external_screen_ids": sorted(observed - declared),
+        "proven_unreachable_screen_ids": len(excluded & declared),
+        "missing_local_screen_ids": sorted(missing),
+        "stale_exclusions": sorted(stale_exclusions),
+        "unsupported_exclusions": sorted(unsupported_exclusions),
+        "missing_modeled_paths": sorted(missing_paths),
+        "unexpected_runtime_paths": sorted(unexpected_paths),
+        "failed_paths": failed_paths,
+        "missing_screen_variants": missing_screen_variants,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--catalog", type=Path, default=HERE / "static_catalog.json")
+    parser.add_argument("--ledger", type=Path, default=HERE / "runtime_ledger.json")
+    parser.add_argument("--classifications", type=Path, default=HERE / "screen_classification.yml")
+    parser.add_argument("--model", type=Path, default=HERE / "coverage_model.yml")
+    parser.add_argument("--output", type=Path, default=HERE / "coverage_audit.json")
+    args = parser.parse_args()
+    classifications = yaml.safe_load(args.classifications.read_text()) if args.classifications.exists() else {}
+    model = yaml.safe_load(args.model.read_text()) if args.model.exists() else {}
+    report = audit(load_json(args.catalog), load_json(args.ledger), classifications or {}, model or {})
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/certification/audit_coverage.py
+++ b/tests/certification/audit_coverage.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import yaml
 
+from model_loader import load_model
+
 
 HERE = Path(__file__).resolve().parent
 
@@ -165,7 +167,7 @@ def main() -> int:
     parser.add_argument("--output", type=Path, default=HERE / "coverage_audit.json")
     args = parser.parse_args()
     classifications = yaml.safe_load(args.classifications.read_text()) if args.classifications.exists() else {}
-    model = yaml.safe_load(args.model.read_text()) if args.model.exists() else {}
+    model = load_model(args.model) if args.model.exists() else {}
     report = audit(load_json(args.catalog), load_json(args.ledger), classifications or {}, model or {})
     args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/certification/audit_coverage.py
+++ b/tests/certification/audit_coverage.py
@@ -98,6 +98,7 @@ def audit(
     excluded = set(exclusions)
     missing = declared - observed_coordinates - excluded
     stale_exclusions = excluded - declared
+    observed_exclusions = excluded & observed_coordinates
     catalog_by_coordinate = {
         screen_coordinate(screen): screen
         for screen in catalog["screens"]
@@ -149,6 +150,7 @@ def audit(
     passed = (
         not missing
         and not stale_exclusions
+        and not observed_exclusions
         and not failed_paths
         and not unsupported_exclusions
         and not missing_paths
@@ -170,6 +172,7 @@ def audit(
         "missing_local_screens": missing_screens,
         "missing_local_screen_ids": sorted({screen["id"] for screen in missing_screens}),
         "stale_exclusions": sorted(stale_exclusions),
+        "observed_exclusions": sorted(observed_exclusions),
         "unsupported_exclusions": sorted(unsupported_exclusions),
         "missing_modeled_paths": sorted(missing_paths),
         "unexpected_runtime_paths": sorted(unexpected_paths),

--- a/tests/certification/audit_coverage.py
+++ b/tests/certification/audit_coverage.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 from pathlib import Path
 from typing import Any
 
@@ -21,17 +20,24 @@ def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text())
 
 
-def normalized_variable(value: Any) -> str:
-    return re.sub(r"\[\d+\]", "[i]", str(value or ""))
+def screen_coordinate(screen: dict[str, Any]) -> str:
+    """Identify one exact YAML screen block, even when IDs are reused."""
+    if screen.get("source_file") and screen.get("source_fingerprint"):
+        return f"{screen['source_file']}#{screen['source_fingerprint']}"
+    return f"id:{screen.get('id', '<unnamed>')}"
 
 
-def static_variant_signature(screen: dict[str, Any]) -> tuple[Any, ...]:
-    return (
-        screen.get("event"),
-        normalized_variable(screen.get("continue_button_field")),
-        tuple(sorted(normalized_variable(value) for value in screen.get("sets") or [])),
-        tuple(sorted(normalized_variable(value) for value in screen.get("variables") or [])),
-    )
+def runtime_screen_records(ledger: dict[str, Any]) -> list[dict[str, Any]]:
+    records = []
+    for result in ledger.get("results", []):
+        result_records = list(result.get("steps", [])) + list(result.get("event_probes", []))
+        if result_records:
+            records.extend(result_records)
+        else:
+            # Compatibility for small hand-built ledgers and historical runs;
+            # production ledgers always carry exact per-step coordinates.
+            records.extend({"id": screen_id} for screen_id in result.get("seen_screen_ids", []))
+    return records
 
 
 def audit(
@@ -40,54 +46,47 @@ def audit(
     classifications: dict[str, Any],
     model: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    observed = {
-        screen_id
-        for result in ledger.get("results", [])
-        for screen_id in result.get("seen_screen_ids", [])
+    runtime_records = runtime_screen_records(ledger)
+    observed_coordinates = {screen_coordinate(record) for record in runtime_records}
+    observed_ids = {
+        str(record["id"])
+        for record in runtime_records
+        if record.get("id")
     }
-    feature_declared = {
-        screen["id"]
+    feature_screens = [
+        screen
         for screen in catalog["screens"]
         if screen.get("coverage_scope", "combined_feature") == "combined_feature"
-    }
-    framework_catalog = {
-        screen["id"]
+    ]
+    framework_screens = [
+        screen
         for screen in catalog["screens"]
         if screen.get("coverage_scope") == "framework_support"
-    }
+    ]
+    feature_declared = {screen_coordinate(screen) for screen in feature_screens}
+    framework_catalog = {screen_coordinate(screen) for screen in framework_screens}
     # Feature-package screens are exhaustive obligations. Framework packages
     # also contain generic saved-session, authoring, and standalone utility
     # screens that this interview never calls; any framework screen actually
     # observed at runtime joins the obligation set automatically.
-    declared = feature_declared | (framework_catalog & observed)
-    static_variants: dict[str, set[tuple[Any, ...]]] = {}
-    for screen in catalog["screens"]:
-        if screen["id"] not in feature_declared:
-            continue
-        static_variants.setdefault(screen["id"], set()).add(static_variant_signature(screen))
-    observed_variants: dict[str, set[str]] = {}
-    for result in ledger.get("results", []):
-        for step in result.get("steps", []):
-            if step.get("id") and step.get("variant_fingerprint"):
-                observed_variants.setdefault(step["id"], set()).add(step["variant_fingerprint"])
-    has_variant_evidence = bool(observed_variants)
-    missing_screen_variants = (
-        {
-            screen_id: {
-                "expected": len(signatures),
-                "observed": len(observed_variants.get(screen_id, set())),
-            }
-            for screen_id, signatures in static_variants.items()
-            if len(observed_variants.get(screen_id, set())) < len(signatures)
-            and screen_id in observed
-        }
-        if has_variant_evidence
-        else {}
-    )
+    declared = feature_declared | (framework_catalog & observed_coordinates)
     exclusions = classifications.get("proven_unreachable", {})
     excluded = set(exclusions)
-    missing = declared - observed - excluded
+    missing = declared - observed_coordinates - excluded
     stale_exclusions = excluded - declared
+    catalog_by_coordinate = {
+        screen_coordinate(screen): screen
+        for screen in catalog["screens"]
+    }
+    missing_screens = [
+        {
+            "coordinate": coordinate,
+            "id": catalog_by_coordinate[coordinate]["id"],
+            "source_file": catalog_by_coordinate[coordinate].get("source_file"),
+            "document_index": catalog_by_coordinate[coordinate].get("document_index"),
+        }
+        for coordinate in sorted(missing)
+    ]
     failed_paths = [
         {
             "name": result.get("name"),
@@ -130,26 +129,27 @@ def audit(
         and not unsupported_exclusions
         and not missing_paths
         and not unexpected_paths
-        and not missing_screen_variants
         and not missing_cardinality_classes
     )
     return {
         "passed": passed,
-        "declared_local_screen_ids": len(declared),
-        "declared_feature_screen_ids": len(feature_declared),
-        "observed_framework_screen_ids": sorted(framework_catalog & observed),
-        "unobserved_framework_catalog_screen_ids": len(framework_catalog - observed),
-        "observed_screen_ids": len(observed),
-        "observed_local_screen_ids": len(declared & observed),
-        "observed_external_screen_ids": sorted(observed - declared),
+        "declared_local_screens": len(declared),
+        "declared_feature_screens": len(feature_declared),
+        "declared_feature_screen_ids": len({screen["id"] for screen in feature_screens}),
+        "observed_framework_screens": len(framework_catalog & observed_coordinates),
+        "unobserved_framework_catalog_screens": len(framework_catalog - observed_coordinates),
+        "observed_screen_coordinates": len(observed_coordinates),
+        "observed_screen_ids": len(observed_ids),
+        "observed_local_screens": len(declared & observed_coordinates),
+        "observed_external_screen_coordinates": sorted(observed_coordinates - declared),
         "proven_unreachable_screen_ids": len(excluded & declared),
-        "missing_local_screen_ids": sorted(missing),
+        "missing_local_screens": missing_screens,
+        "missing_local_screen_ids": sorted({screen["id"] for screen in missing_screens}),
         "stale_exclusions": sorted(stale_exclusions),
         "unsupported_exclusions": sorted(unsupported_exclusions),
         "missing_modeled_paths": sorted(missing_paths),
         "unexpected_runtime_paths": sorted(unexpected_paths),
         "failed_paths": failed_paths,
-        "missing_screen_variants": missing_screen_variants,
         "missing_cardinality_classes": missing_cardinality_classes,
         "observed_cardinality_classes": {
             name: sorted(values)

--- a/tests/certification/audit_coverage.py
+++ b/tests/certification/audit_coverage.py
@@ -38,14 +38,30 @@ def audit(
     classifications: dict[str, Any],
     model: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    declared = {screen["id"] for screen in catalog["screens"]}
     observed = {
         screen_id
         for result in ledger.get("results", [])
         for screen_id in result.get("seen_screen_ids", [])
     }
+    feature_declared = {
+        screen["id"]
+        for screen in catalog["screens"]
+        if screen.get("coverage_scope", "combined_feature") == "combined_feature"
+    }
+    framework_catalog = {
+        screen["id"]
+        for screen in catalog["screens"]
+        if screen.get("coverage_scope") == "framework_support"
+    }
+    # Feature-package screens are exhaustive obligations. Framework packages
+    # also contain generic saved-session, authoring, and standalone utility
+    # screens that this interview never calls; any framework screen actually
+    # observed at runtime joins the obligation set automatically.
+    declared = feature_declared | (framework_catalog & observed)
     static_variants: dict[str, set[tuple[Any, ...]]] = {}
     for screen in catalog["screens"]:
+        if screen["id"] not in feature_declared:
+            continue
         static_variants.setdefault(screen["id"], set()).add(static_variant_signature(screen))
     observed_variants: dict[str, set[str]] = {}
     for result in ledger.get("results", []):
@@ -86,6 +102,22 @@ def audit(
     observed_paths = {result.get("name") for result in ledger.get("results", [])}
     missing_paths = expected_paths - observed_paths
     unexpected_paths = observed_paths - expected_paths if expected_paths else set()
+    expected_cardinality_classes = {
+        name: set(values)
+        for name, values in (model or {}).get("cardinality_classes", {}).items()
+    }
+    observed_cardinality_classes: dict[str, set[int]] = {}
+    for result in ledger.get("results", []):
+        if result.get("status") != "pass":
+            continue
+        for name, evidence in result.get("cardinality_evidence", {}).items():
+            if isinstance(evidence.get("observed"), int):
+                observed_cardinality_classes.setdefault(name, set()).add(evidence["observed"])
+    missing_cardinality_classes = {
+        name: sorted(values - observed_cardinality_classes.get(name, set()))
+        for name, values in expected_cardinality_classes.items()
+        if values - observed_cardinality_classes.get(name, set())
+    }
     passed = (
         not missing
         and not stale_exclusions
@@ -94,10 +126,14 @@ def audit(
         and not missing_paths
         and not unexpected_paths
         and not missing_screen_variants
+        and not missing_cardinality_classes
     )
     return {
         "passed": passed,
         "declared_local_screen_ids": len(declared),
+        "declared_feature_screen_ids": len(feature_declared),
+        "observed_framework_screen_ids": sorted(framework_catalog & observed),
+        "unobserved_framework_catalog_screen_ids": len(framework_catalog - observed),
         "observed_screen_ids": len(observed),
         "observed_local_screen_ids": len(declared & observed),
         "observed_external_screen_ids": sorted(observed - declared),
@@ -109,6 +145,11 @@ def audit(
         "unexpected_runtime_paths": sorted(unexpected_paths),
         "failed_paths": failed_paths,
         "missing_screen_variants": missing_screen_variants,
+        "missing_cardinality_classes": missing_cardinality_classes,
+        "observed_cardinality_classes": {
+            name: sorted(values)
+            for name, values in observed_cardinality_classes.items()
+        },
     }
 
 

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -19,7 +19,7 @@
     {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "pull_request": 3,
-      "sha": "2f7e7fdc0458269854bd8468b7cc20edcfbf3510",
+      "sha": "ef8c913bf1c9d585fa704be7934c599afeb8df9e",
       "reason": "Fix API rendering of the multi-child custody checkbox question"
     }
   ],
@@ -66,7 +66,7 @@
     "docassemble.MATCChildCareOrCustodyDisclosureAffidavit": {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "directory": "docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
-      "sha": "2f7e7fdc0458269854bd8468b7cc20edcfbf3510"
+      "sha": "ef8c913bf1c9d585fa704be7934c599afeb8df9e"
     },
     "docassemble.MATCCSGWorksheet": {
       "repository": "SuffolkLITLab/docassemble-MATCCSGWorksheet",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -56,7 +56,7 @@
     "docassemble.MATCFinancialStatement": {
       "repository": "SuffolkLITLab/docassemble-MATCFinancialStatement",
       "directory": "docassemble-MATCFinancialStatement",
-      "sha": "ec4f14f274e640836608ed14ad9a709ffb1ba1ab"
+      "sha": "a1dbe3d228c7f36674217103abb082ae35610741"
     },
     "docassemble.MATCSeparationAgreement": {
       "repository": "SuffolkLITLab/docassemble-MATCSeparationAgreement",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -17,6 +17,25 @@
       "reason": "Known fix for the separation-agreement merge loop"
     }
   ],
+  "coverage_scope": {
+    "feature_packages": [
+      "docassemble.MATC1ADivorceJointPetition",
+      "docassemble.MATCMotionToAmend",
+      "docassemble.MATCFinancialStatement",
+      "docassemble.MATCSeparationAgreement",
+      "docassemble.MATCChildCareOrCustodyDisclosureAffidavit",
+      "docassemble.MATCCSGWorksheet",
+      "docassemble.matcfindingsanddeterminations",
+      "docassemble.ALAffidavitOfIndigency"
+    ],
+    "framework_packages": [
+      "docassemble.AssemblyLine",
+      "docassemble.ALMassachusetts",
+      "docassemble.ALToolbox",
+      "docassemble.MassAccess",
+      "docassemble.GithubFeedbackForm"
+    ]
+  },
   "packages": {
     "docassemble.MATC1ADivorceJointPetition": {
       "repository": "SuffolkLITLab/docassemble-MATC1ADivorceJointPetition",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -56,7 +56,7 @@
     "docassemble.MATCFinancialStatement": {
       "repository": "SuffolkLITLab/docassemble-MATCFinancialStatement",
       "directory": "docassemble-MATCFinancialStatement",
-      "sha": "34d478e545002446ce3ecda432b337ebd3400a8a"
+      "sha": "ec4f14f274e640836608ed14ad9a709ffb1ba1ab"
     },
     "docassemble.MATCSeparationAgreement": {
       "repository": "SuffolkLITLab/docassemble-MATCSeparationAgreement",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -19,7 +19,7 @@
     {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "pull_request": 3,
-      "sha": "ee3beb62b2e20cd2c864c2f129c4a4dcb8625aea",
+      "sha": "08f31c860457e41ea757d3b1f8469c74a7a53556",
       "reason": "Fix API rendering of the multi-child custody checkbox question"
     }
   ],
@@ -66,7 +66,7 @@
     "docassemble.MATCChildCareOrCustodyDisclosureAffidavit": {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "directory": "docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
-      "sha": "ee3beb62b2e20cd2c864c2f129c4a4dcb8625aea"
+      "sha": "08f31c860457e41ea757d3b1f8469c74a7a53556"
     },
     "docassemble.MATCCSGWorksheet": {
       "repository": "SuffolkLITLab/docassemble-MATCCSGWorksheet",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -15,6 +15,12 @@
       "pull_request": 159,
       "sha": "5519eb22068534a82d93f49a2650617077618054",
       "reason": "Known fix for the separation-agreement merge loop"
+    },
+    {
+      "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
+      "pull_request": 3,
+      "sha": "2f7e7fdb95cb330d59fb61eea00575f3849080f0",
+      "reason": "Fix API rendering of the multi-child custody checkbox question"
     }
   ],
   "coverage_scope": {
@@ -60,7 +66,7 @@
     "docassemble.MATCChildCareOrCustodyDisclosureAffidavit": {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "directory": "docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
-      "sha": "a08c02e0ead0a108cb062ce4f7db34e00bdbb0fe"
+      "sha": "2f7e7fdb95cb330d59fb61eea00575f3849080f0"
     },
     "docassemble.MATCCSGWorksheet": {
       "repository": "SuffolkLITLab/docassemble-MATCCSGWorksheet",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -1,0 +1,63 @@
+{
+  "entrypoint": "docassemble.MATC1ADivorceJointPetition:data/questions/main_joint_petition.yml",
+  "source": {
+    "repository": "SuffolkLITLab/docassemble-MATC1ADivorceJointPetition",
+    "ref": "main",
+    "sha": "d7063d1ebd3ceb59808ac6934c40849ee0189a7a"
+  },
+  "runtime": {
+    "image": "jhpyle/docassemble@sha256:c0b0a707a6cd2149d5777ee83af1ea1de544210e597371eac93e67a1503c395c"
+  },
+  "candidate_overlays": [
+    {
+      "repository": "SuffolkLITLab/docassemble-MATC1ADivorceJointPetition",
+      "pull_request": 159,
+      "sha": "5519eb22068534a82d93f49a2650617077618054",
+      "reason": "Known fix for the separation-agreement merge loop"
+    }
+  ],
+  "packages": {
+    "docassemble.MATC1ADivorceJointPetition": {
+      "repository": "SuffolkLITLab/docassemble-MATC1ADivorceJointPetition",
+      "directory": "docassemble-MATC1ADivorceJointPetition",
+      "sha": "d7063d1ebd3ceb59808ac6934c40849ee0189a7a"
+    },
+    "docassemble.MATCMotionToAmend": {
+      "repository": "SuffolkLITLab/docassemble-MATCMotionToAmend",
+      "directory": "docassemble-MATCMotionToAmend",
+      "sha": "f92797e3c417f142faec40fbce35d25fb8bf50d6"
+    },
+    "docassemble.MATCFinancialStatement": {
+      "repository": "SuffolkLITLab/docassemble-MATCFinancialStatement",
+      "directory": "docassemble-MATCFinancialStatement",
+      "sha": "73d1cab3f2425bc78ed15a6d4b6208236e16faf4"
+    },
+    "docassemble.MATCSeparationAgreement": {
+      "repository": "SuffolkLITLab/docassemble-MATCSeparationAgreement",
+      "directory": "docassemble-MATCSeparationAgreement",
+      "sha": "dce8a19a3249a7be750ddc326913bc2bb93c6dfe"
+    },
+    "docassemble.MATCChildCareOrCustodyDisclosureAffidavit": {
+      "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
+      "directory": "docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
+      "sha": "a08c02e0ead0a108cb062ce4f7db34e00bdbb0fe"
+    },
+    "docassemble.MATCCSGWorksheet": {
+      "repository": "SuffolkLITLab/docassemble-MATCCSGWorksheet",
+      "directory": "docassemble-MATCCSGWorksheet",
+      "sha": "96589474face58e0bbb18a067f4710e8e50e3d5a"
+    },
+    "docassemble.matcfindingsanddeterminations": {
+      "repository": "SuffolkLITLab/docassemble-MATCFindingsAndDeterminations",
+      "directory": "docassemble-MATCFindingsAndDeterminations",
+      "sha": "9ce10b5f65b0fdd83919d151dee6d9a717723b26"
+    }
+  },
+  "external_packages": [
+    "docassemble.AssemblyLine",
+    "docassemble.ALMassachusetts",
+    "docassemble.ALToolbox",
+    "docassemble.MassAccess",
+    "docassemble.ALAffidavitOfIndigency"
+  ]
+}

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -19,7 +19,7 @@
     {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "pull_request": 3,
-      "sha": "2f7e7fdb95cb330d59fb61eea00575f3849080f0",
+      "sha": "2f7e7fdc0458269854bd8468b7cc20edcfbf3510",
       "reason": "Fix API rendering of the multi-child custody checkbox question"
     }
   ],
@@ -66,7 +66,7 @@
     "docassemble.MATCChildCareOrCustodyDisclosureAffidavit": {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "directory": "docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
-      "sha": "2f7e7fdb95cb330d59fb61eea00575f3849080f0"
+      "sha": "2f7e7fdc0458269854bd8468b7cc20edcfbf3510"
     },
     "docassemble.MATCCSGWorksheet": {
       "repository": "SuffolkLITLab/docassemble-MATCCSGWorksheet",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -6,7 +6,8 @@
     "sha": "d7063d1ebd3ceb59808ac6934c40849ee0189a7a"
   },
   "runtime": {
-    "image": "jhpyle/docassemble@sha256:c0b0a707a6cd2149d5777ee83af1ea1de544210e597371eac93e67a1503c395c"
+    "image": "jhpyle/docassemble@sha256:c0b0a707a6cd2149d5777ee83af1ea1de544210e597371eac93e67a1503c395c",
+    "pip_freeze_sha256": "66b4611da4865095c1a70e2631ce8c553cadb51e8643ab54adb2f86df57f4e79"
   },
   "candidate_overlays": [
     {
@@ -51,13 +52,44 @@
       "repository": "SuffolkLITLab/docassemble-MATCFindingsAndDeterminations",
       "directory": "docassemble-MATCFindingsAndDeterminations",
       "sha": "9ce10b5f65b0fdd83919d151dee6d9a717723b26"
+    },
+    "docassemble.AssemblyLine": {
+      "repository": "SuffolkLITLab/docassemble-AssemblyLine",
+      "directory": "docassemble-AssemblyLine",
+      "sha": "1c435280ef9c27ed582944dbc1b8c71f8e662521"
+    },
+    "docassemble.ALMassachusetts": {
+      "repository": "SuffolkLITLab/docassemble-ALMassachusetts",
+      "directory": "docassemble-ALMassachusetts",
+      "sha": "854cbc7efc970f6f185bfcbcc6643c271632e0ca"
+    },
+    "docassemble.ALToolbox": {
+      "repository": "SuffolkLITLab/docassemble-ALToolbox",
+      "directory": "docassemble-ALToolbox",
+      "sha": "acbb22a0c5c7cffb3b4d1a1ca77971d047791639"
+    },
+    "docassemble.MassAccess": {
+      "repository": "SuffolkLITLab/docassemble-MassAccess",
+      "directory": "docassemble-MassAccess",
+      "sha": "daf7a99dba0eff96c4fda9f90800f8464c4492e7"
+    },
+    "docassemble.ALAffidavitOfIndigency": {
+      "repository": "SuffolkLITLab/docassemble-ALAffidavitOfIndigency",
+      "directory": "docassemble-ALAffidavitOfIndigency",
+      "sha": "414918eabd2ca2bcbbac15dccb30343aa1ff9e47"
+    },
+    "docassemble.GithubFeedbackForm": {
+      "repository": "SuffolkLITLab/docassemble-GithubFeedbackForm",
+      "directory": "docassemble-GithubFeedbackForm",
+      "sha": "ba9baa908425d12a2ea6ac7167f61aaecc570875"
     }
   },
-  "external_packages": [
-    "docassemble.AssemblyLine",
-    "docassemble.ALMassachusetts",
-    "docassemble.ALToolbox",
-    "docassemble.MassAccess",
-    "docassemble.ALAffidavitOfIndigency"
-  ]
+  "external_packages": {
+    "docassemble.AssemblyLine": "4.7.0",
+    "docassemble.ALMassachusetts": "0.3.0",
+    "docassemble.ALToolbox": "0.19.0",
+    "docassemble.MassAccess": "0.4.3",
+    "docassemble.ALAffidavitOfIndigency": "2.3.0",
+    "docassemble.GithubFeedbackForm": "0.5.6"
+  }
 }

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -56,7 +56,7 @@
     "docassemble.MATCFinancialStatement": {
       "repository": "SuffolkLITLab/docassemble-MATCFinancialStatement",
       "directory": "docassemble-MATCFinancialStatement",
-      "sha": "73d1cab3f2425bc78ed15a6d4b6208236e16faf4"
+      "sha": "34d478e545002446ce3ecda432b337ebd3400a8a"
     },
     "docassemble.MATCSeparationAgreement": {
       "repository": "SuffolkLITLab/docassemble-MATCSeparationAgreement",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -19,7 +19,7 @@
     {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "pull_request": 3,
-      "sha": "9c6592941af434c392db172dc3b26670f1fe8960",
+      "sha": "ee3beb62b2e20cd2c864c2f129c4a4dcb8625aea",
       "reason": "Fix API rendering of the multi-child custody checkbox question"
     }
   ],
@@ -66,7 +66,7 @@
     "docassemble.MATCChildCareOrCustodyDisclosureAffidavit": {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "directory": "docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
-      "sha": "9c6592941af434c392db172dc3b26670f1fe8960"
+      "sha": "ee3beb62b2e20cd2c864c2f129c4a4dcb8625aea"
     },
     "docassemble.MATCCSGWorksheet": {
       "repository": "SuffolkLITLab/docassemble-MATCCSGWorksheet",

--- a/tests/certification/baseline.json
+++ b/tests/certification/baseline.json
@@ -19,7 +19,7 @@
     {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "pull_request": 3,
-      "sha": "ef8c913bf1c9d585fa704be7934c599afeb8df9e",
+      "sha": "9c6592941af434c392db172dc3b26670f1fe8960",
       "reason": "Fix API rendering of the multi-child custody checkbox question"
     }
   ],
@@ -66,7 +66,7 @@
     "docassemble.MATCChildCareOrCustodyDisclosureAffidavit": {
       "repository": "SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
       "directory": "docassemble-MATCChildCareOrCustodyDisclosureAffidavit",
-      "sha": "ef8c913bf1c9d585fa704be7934c599afeb8df9e"
+      "sha": "9c6592941af434c392db172dc3b26670f1fe8960"
     },
     "docassemble.MATCCSGWorksheet": {
       "repository": "SuffolkLITLab/docassemble-MATCCSGWorksheet",

--- a/tests/certification/build_catalog.py
+++ b/tests/certification/build_catalog.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -107,6 +108,21 @@ def screen_variant_signature(screen: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def source_document_fingerprint(document: dict[str, Any]) -> str:
+    payload = {
+        key: value
+        for key, value in document.items()
+        if not str(key).startswith("_")
+    }
+    serialized = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(serialized.encode()).hexdigest()[:16]
+
+
 def iter_documents(path: Path) -> Iterable[dict[str, Any]]:
     for index, document in enumerate(yaml.safe_load_all(path.read_text()), start=1):
         if isinstance(document, dict):
@@ -167,6 +183,7 @@ def build_catalog(workspace: Path, baseline: dict[str, Any]) -> dict[str, Any]:
             question_id = document.get("id")
             if question_id:
                 fields = document.get("fields") or []
+                relative_source = path.relative_to(roots[current_package]).as_posix()
                 block = {
                     "id": str(question_id),
                     "kind": document_kind(document),
@@ -179,6 +196,8 @@ def build_catalog(workspace: Path, baseline: dict[str, Any]) -> dict[str, Any]:
                         "combined_feature" if current_package in feature_packages else "framework_support"
                     ),
                     "path": file_record["path"],
+                    "source_file": f"{current_package}:data/questions/{relative_source}",
+                    "source_fingerprint": source_document_fingerprint(document),
                     "document_index": document["_document_index"],
                     "variables": direct_question_variables(document)
                     + [v for v in (field_variable(f) for f in fields) if v],

--- a/tests/certification/build_catalog.py
+++ b/tests/certification/build_catalog.py
@@ -123,6 +123,12 @@ def build_catalog(workspace: Path, baseline: dict[str, Any]) -> dict[str, Any]:
     entry_package, entry_relative = parse_interview_name(baseline["entrypoint"])
     if entry_package is None:
         raise ValueError("The entrypoint must use a docassemble package name")
+    feature_packages = set(baseline.get("coverage_scope", {}).get("feature_packages", []))
+    framework_packages = set(baseline.get("coverage_scope", {}).get("framework_packages", []))
+    if feature_packages | framework_packages != set(roots):
+        raise ValueError("coverage_scope must classify every pinned package exactly once")
+    if feature_packages & framework_packages:
+        raise ValueError("coverage_scope package classifications must not overlap")
 
     pending: list[tuple[str, Path]] = [(entry_package, roots[entry_package] / entry_relative)]
     visited: set[Path] = set()
@@ -169,6 +175,9 @@ def build_catalog(workspace: Path, baseline: dict[str, Any]) -> dict[str, Any]:
                     "sets": document.get("sets"),
                     "continue_button_field": document.get("continue button field"),
                     "package": current_package,
+                    "coverage_scope": (
+                        "combined_feature" if current_package in feature_packages else "framework_support"
+                    ),
                     "path": file_record["path"],
                     "document_index": document["_document_index"],
                     "variables": direct_question_variables(document)
@@ -205,6 +214,7 @@ def build_catalog(workspace: Path, baseline: dict[str, Any]) -> dict[str, Any]:
     return {
         "entrypoint": baseline["entrypoint"],
         "source_sha": baseline["source"]["sha"],
+        "coverage_scope": baseline["coverage_scope"],
         "files": sorted(files, key=lambda item: item["path"]),
         "blocks": sorted(blocks, key=lambda item: (item["path"], item["document_index"])),
         "screens": sorted(screens, key=lambda item: (item["path"], item["document_index"])),

--- a/tests/certification/build_catalog.py
+++ b/tests/certification/build_catalog.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Build a deterministic static catalog for the combined 1A interview.
+
+The catalog is one half of the coverage proof. Runtime traversal must account
+for every reachable ID in this catalog and must separately record screens from
+external packages that are only visible after Docassemble resolves includes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def package_question_root(workspace: Path, package: str, spec: dict[str, Any]) -> Path:
+    namespace = package.split(".", 1)[1]
+    return workspace / spec["directory"] / "docassemble" / namespace / "data" / "questions"
+
+
+def parse_interview_name(name: str) -> tuple[str | None, str]:
+    if ":" not in name:
+        return None, name
+    package, relative = name.split(":", 1)
+    prefix = "data/questions/"
+    if relative.startswith(prefix):
+        relative = relative[len(prefix) :]
+    return package, relative
+
+
+def field_variable(field: Any) -> str | None:
+    if not isinstance(field, dict):
+        return None
+    metadata_keys = {
+        "datatype", "choices", "required", "show if", "hide if", "help",
+        "hint", "default", "code", "min", "max", "validation messages",
+        "rows", "input type", "address autocomplete",
+    }
+    for key, value in field.items():
+        if key not in metadata_keys and isinstance(value, str):
+            return value
+    return None
+
+
+def choice_values(field: Any) -> list[Any]:
+    if not isinstance(field, dict):
+        return []
+    choices = field.get("choices")
+    if not isinstance(choices, list):
+        return []
+    result: list[Any] = []
+    for choice in choices:
+        if isinstance(choice, dict) and len(choice) == 1:
+            result.append(next(iter(choice.values())))
+        elif isinstance(choice, (str, int, float, bool)):
+            result.append(choice)
+    return result
+
+
+def branch_expressions(code: str) -> list[str]:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+    expressions: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.If, ast.IfExp, ast.While)):
+            segment = ast.get_source_segment(code, node.test)
+            if segment:
+                expressions.add(" ".join(segment.split()))
+    return sorted(expressions)
+
+
+def document_kind(document: dict[str, Any]) -> str:
+    for kind in ("question", "event", "code", "attachment", "attachments", "template", "objects"):
+        if kind in document:
+            return kind
+    return "configuration"
+
+
+def direct_question_variables(document: dict[str, Any]) -> list[str]:
+    result = []
+    for key in ("field", "yesno", "noyes", "signature", "dropdown", "combobox", "range"):
+        value = document.get(key)
+        if isinstance(value, str):
+            result.append(value)
+    return result
+
+
+def screen_variant_signature(screen: dict[str, Any]) -> tuple[Any, ...]:
+    normalize = lambda value: re.sub(r"\[\d+\]", "[i]", str(value or ""))
+    return (
+        screen["id"],
+        screen.get("event"),
+        normalize(screen.get("continue_button_field")),
+        tuple(sorted(normalize(value) for value in screen.get("sets") or [])),
+        tuple(sorted(normalize(value) for value in screen.get("variables") or [])),
+    )
+
+
+def iter_documents(path: Path) -> Iterable[dict[str, Any]]:
+    for index, document in enumerate(yaml.safe_load_all(path.read_text()), start=1):
+        if isinstance(document, dict):
+            document = dict(document)
+            document["_document_index"] = index
+            yield document
+
+
+def build_catalog(workspace: Path, baseline: dict[str, Any]) -> dict[str, Any]:
+    roots = {
+        package: package_question_root(workspace, package, spec)
+        for package, spec in baseline["packages"].items()
+    }
+    entry_package, entry_relative = parse_interview_name(baseline["entrypoint"])
+    if entry_package is None:
+        raise ValueError("The entrypoint must use a docassemble package name")
+
+    pending: list[tuple[str, Path]] = [(entry_package, roots[entry_package] / entry_relative)]
+    visited: set[Path] = set()
+    unresolved: set[str] = set()
+    files: list[dict[str, Any]] = []
+    blocks: list[dict[str, Any]] = []
+    screens: list[dict[str, Any]] = []
+    branches: list[dict[str, Any]] = []
+
+    while pending:
+        current_package, path = pending.pop()
+        path = path.resolve()
+        if path in visited:
+            continue
+        visited.add(path)
+        if not path.exists():
+            unresolved.add(f"{current_package}:{path.name}")
+            continue
+
+        file_record = {
+            "package": current_package,
+            "path": str(path.relative_to(workspace)),
+            "documents": 0,
+        }
+        for document in iter_documents(path):
+            file_record["documents"] += 1
+            for include in document.get("include", []) or []:
+                include_package, include_relative = parse_interview_name(str(include))
+                if include_package is None:
+                    pending.append((current_package, path.parent / include_relative))
+                elif include_package in roots:
+                    pending.append((include_package, roots[include_package] / include_relative))
+                else:
+                    unresolved.add(str(include))
+
+            question_id = document.get("id")
+            if question_id:
+                fields = document.get("fields") or []
+                block = {
+                    "id": str(question_id),
+                    "kind": document_kind(document),
+                    "event": document.get("event"),
+                    "mandatory": document.get("mandatory", False),
+                    "sets": document.get("sets"),
+                    "continue_button_field": document.get("continue button field"),
+                    "package": current_package,
+                    "path": file_record["path"],
+                    "document_index": document["_document_index"],
+                    "variables": direct_question_variables(document)
+                    + [v for v in (field_variable(f) for f in fields) if v],
+                    "choice_values": {
+                        variable: choice_values(field)
+                        for field in fields
+                        if (variable := field_variable(field)) and choice_values(field)
+                    },
+                }
+                blocks.append(block)
+                if "question" in document or "event" in document:
+                    screens.append(block)
+
+            code = document.get("code")
+            if isinstance(code, str):
+                for expression in branch_expressions(code):
+                    branches.append(
+                        {
+                            "expression": expression,
+                            "package": current_package,
+                            "path": file_record["path"],
+                            "document_index": document["_document_index"],
+                            "id": question_id,
+                        }
+                    )
+        files.append(file_record)
+
+    duplicate_ids: dict[str, list[str]] = {}
+    for block in blocks:
+        duplicate_ids.setdefault(block["id"], []).append(block["path"])
+    duplicate_ids = {key: value for key, value in duplicate_ids.items() if len(value) > 1}
+
+    return {
+        "entrypoint": baseline["entrypoint"],
+        "source_sha": baseline["source"]["sha"],
+        "files": sorted(files, key=lambda item: item["path"]),
+        "blocks": sorted(blocks, key=lambda item: (item["path"], item["document_index"])),
+        "screens": sorted(screens, key=lambda item: (item["path"], item["document_index"])),
+        "branches": sorted(branches, key=lambda item: (item["path"], item["document_index"], item["expression"])),
+        "unresolved_external_includes": sorted(unresolved),
+        "duplicate_ids": duplicate_ids,
+        "counts": {
+            "files": len(files),
+            "identified_blocks": len(blocks),
+            "unique_block_ids": len({block["id"] for block in blocks}),
+            "screens": len(screens),
+            "unique_screen_ids": len({screen["id"] for screen in screens}),
+            "unique_screen_variants": len({screen_variant_signature(screen) for screen in screens}),
+            "branch_expressions": len(branches),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    here = Path(__file__).resolve().parent
+    parser.add_argument("--workspace", type=Path, default=here.parents[2])
+    parser.add_argument("--baseline", type=Path, default=here / "baseline.json")
+    parser.add_argument("--output", type=Path, default=here / "static_catalog.json")
+    args = parser.parse_args()
+
+    catalog = build_catalog(args.workspace.resolve(), load_json(args.baseline))
+    args.output.write_text(json.dumps(catalog, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(catalog["counts"], sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/certification/checkout_packages.py
+++ b/tests/certification/checkout_packages.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Check out the exact local-package commits declared in baseline.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def run(*command: str, cwd: Path | None = None) -> None:
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workspace", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path, default=HERE / "baseline.json")
+    parser.add_argument("--skip", action="append", default=[])
+    args = parser.parse_args()
+    baseline = json.loads(args.baseline.read_text())
+    args.workspace.mkdir(parents=True, exist_ok=True)
+
+    for package, spec in baseline["packages"].items():
+        if package in args.skip:
+            continue
+        destination = args.workspace / spec["directory"]
+        if not destination.exists():
+            run("git", "clone", f"https://github.com/{spec['repository']}.git", str(destination))
+        run("git", "fetch", "--all", "--prune", cwd=destination)
+        run("git", "checkout", "--detach", spec["sha"], cwd=destination)
+        actual = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=destination, text=True).strip()
+        if actual != spec["sha"]:
+            raise RuntimeError(f"{package}: expected {spec['sha']}, got {actual}")
+        print(f"{package} {actual}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -365,6 +365,7 @@ numeric_boundaries:
   number_of_children_eligible: [1, 2, 3, 4, 5, 6]
 
 hang_policy:
+  runtime_workers: 2
   request_timeout_seconds: 60
   scenario_timeout_seconds: 900
   max_steps: 500

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -2,10 +2,13 @@ model_version: 1
 entrypoint: docassemble.MATC1ADivorceJointPetition:data/questions/main_joint_petition.yml
 default_terminal_ids:
   - download divorce joint petition
+default_probe_events:
+  - event: review_divorcejointpetition
+    expected_id: divorce joint petition review screen
 
-# The crawler explores every listed value whenever the variable is presented.
-# Fields not listed here receive one valid representative value unless a
-# validation rule requires a boundary representative.
+# Every listed value must appear in a declared modeled path. Runtime evidence
+# then proves the resulting screen sequence; fields outside the model receive
+# one valid representative unless a boundary case requires another value.
 dimensions:
   has_existing_1b_action: [false, true]
   financial_statement_scope: [neither, spouse_1_only, spouse_2_only, both]

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -1,0 +1,351 @@
+model_version: 1
+entrypoint: docassemble.MATC1ADivorceJointPetition:data/questions/main_joint_petition.yml
+default_terminal_ids:
+  - download divorce joint petition
+
+# The crawler explores every listed value whenever the variable is presented.
+# Fields not listed here receive one valid representative value unless a
+# validation rule requires a boundary representative.
+dimensions:
+  has_existing_1b_action: [false, true]
+  financial_statement_scope: [neither, spouse_1_only, spouse_2_only, both]
+  legal_marriage: [false, true]
+  international_marriage: [false, true]
+  massachusetts_residency: [false, true]
+  couple_ever_lived_in_massachusetts: [false, true]
+  breakdown_in_massachusetts: [false, true]
+  divorce_affirm: [false, true]
+  joint_petition_affirm: [false, true]
+  separation_agreement_reached: [false, true]
+  parties_will_negotiate: [false, true]
+  separation_agreement_format: [wait, upload, interview]
+  csg_worksheet_path: [wait, upload, interview]
+  children_of_marriage: [false, true]
+  previous_action: [false, true]
+  users[0].has_attorney: [false, true]
+  users[1].has_attorney: [false, true]
+  ask_if_qualifies_for_fee_waiver: [false, true]
+  uploaded_agreement_addresses_child_support: [false, true]
+  uploaded_agreement_child_support_deviation: [false, true]
+  child_support_deviation: [false, true]
+
+default_variables:
+  has_existing_1b_action: false
+  financial_statement_scope: neither
+  legal_marriage: true
+  marriage_certificate_upload: ''
+  massachusetts_residency: true
+  divorce_type_affirmations:
+    want_divorce: true
+    file_jointly: true
+    will_notarize: true
+  children_of_marriage: false
+  children_of_marriage_number: 0
+  separation_agreement_reached: true
+  separation_agreement_documented: false
+  separation_agreement_format: wait
+  uploaded_agreement_addresses_child_support: false
+  uploaded_agreement_child_support_deviation: false
+  child_support_deviation: false
+  international_marriage: false
+  previous_action: false
+  who_lives_at_marital_home: both
+  users[0].has_attorney: false
+  users[1].has_attorney: false
+  users[0].name.first: Alex
+  users[0].name.last: Example
+  users[1].name.first: Bailey
+  users[1].name.last: Example
+  users[0].address.address: 1 Main Street
+  users[0].address.city: Boston
+  users[0].address.state: MA
+  users[0].address.zip: '02108'
+  users[1].address.address: 1 Main Street
+  users[1].address.city: Boston
+  users[1].address.state: MA
+  users[1].address.zip: '02108'
+  marital_home.address: 1 Main Street
+  marital_home.city: Boston
+  marital_home.state: MA
+  marital_home.zip: '02108'
+  ask_if_qualifies_for_fee_waiver: false
+
+# These are the finite path archetypes. Each entry is a complete modeled path:
+# the generator overlays it on default_variables and the runtime ledger proves
+# the actual screen sequence. The set expands until every reachable local
+# screen and every dimension value is accounted for.
+modeled_paths:
+  - name: baseline no children agreement later
+    family: baseline
+    overrides: {}
+
+  - name: legal marriage warning
+    family: eligibility
+    overrides:
+      legal_marriage: false
+
+  - name: jurisdiction warning no marital Massachusetts residence
+    family: eligibility
+    overrides:
+      massachusetts_residency: false
+      couple_ever_lived_in_massachusetts: false
+
+  - name: jurisdiction warning breakdown outside Massachusetts
+    family: eligibility
+    overrides:
+      massachusetts_residency: false
+      couple_ever_lived_in_massachusetts: true
+      breakdown_in_massachusetts: false
+
+  - name: alternate jurisdiction qualifies
+    family: eligibility
+    overrides:
+      massachusetts_residency: false
+      couple_ever_lived_in_massachusetts: true
+      breakdown_in_massachusetts: true
+
+  - name: divorce desire unchecked
+    family: eligibility
+    overrides:
+      divorce_type_affirmations:
+        want_divorce: false
+        file_jointly: true
+        will_notarize: true
+
+  - name: joint filing unchecked
+    family: eligibility
+    overrides:
+      divorce_type_affirmations:
+        want_divorce: true
+        file_jointly: false
+        will_notarize: true
+
+  - name: notarization unchecked
+    family: eligibility
+    overrides:
+      divorce_type_affirmations:
+        want_divorce: true
+        file_jointly: true
+        will_notarize: false
+
+  - name: all 1A affirmations unchecked
+    family: eligibility
+    overrides:
+      divorce_type_affirmations:
+        want_divorce: false
+        file_jointly: false
+        will_notarize: false
+
+  - name: existing 1B party A plaintiff
+    family: existing_case
+    overrides:
+      has_existing_1b_action: true
+      plaintiff_is_party_a: true
+
+  - name: existing 1B party B plaintiff
+    family: existing_case
+    overrides:
+      has_existing_1b_action: true
+      plaintiff_is_party_a: false
+
+  - name: both spouses represented
+    family: counsel
+    overrides:
+      users[0].has_attorney: true
+      users[1].has_attorney: true
+
+  - name: only party A represented
+    family: counsel
+    overrides:
+      users[0].has_attorney: true
+
+  - name: only party B represented
+    family: counsel
+    overrides:
+      users[1].has_attorney: true
+
+  - name: no agreement and unwilling to negotiate
+    family: agreement
+    overrides:
+      separation_agreement_reached: false
+      parties_will_negotiate: false
+
+  - name: negotiate and create childless agreement
+    family: agreement
+    overrides:
+      separation_agreement_reached: false
+      parties_will_negotiate: true
+      separation_agreement_format: interview
+
+  - name: upload childless agreement
+    family: agreement
+    overrides:
+      separation_agreement_documented: true
+      separation_agreement_format: upload
+      separation_agreement_upload:
+        $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
+
+  - name: one child worksheet later agreement later
+    family: children
+    overrides:
+      children_of_marriage: true
+      children_of_marriage_number: 1
+      csg_worksheet_path: wait
+
+  - name: two children uploaded worksheet uploaded agreement no deviation
+    family: children
+    overrides:
+      children_of_marriage: true
+      children_of_marriage_number: 2
+      csg_worksheet_path: upload
+      child_support_guidelines_worksheet_upload:
+        $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
+      separation_agreement_documented: true
+      separation_agreement_format: upload
+      separation_agreement_upload:
+        $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
+      uploaded_agreement_addresses_child_support: true
+      uploaded_agreement_child_support_deviation: false
+
+  - name: four children uploaded worksheet uploaded agreement deviation
+    family: children
+    overrides:
+      children_of_marriage: true
+      children_of_marriage_number: 4
+      csg_worksheet_path: upload
+      child_support_guidelines_worksheet_upload:
+        $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
+      separation_agreement_documented: true
+      separation_agreement_format: upload
+      separation_agreement_upload:
+        $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
+      uploaded_agreement_addresses_child_support: true
+      uploaded_agreement_child_support_deviation: true
+
+  - name: five children built worksheet built agreement
+    family: children
+    overrides:
+      children_of_marriage: true
+      children_of_marriage_number: 5
+      csg_worksheet_path: interview
+      separation_agreement_format: interview
+      child_support_deviation: false
+
+  - name: nine children built worksheet built agreement deviation
+    family: children
+    overrides:
+      children_of_marriage: true
+      children_of_marriage_number: 9
+      csg_worksheet_path: interview
+      separation_agreement_format: interview
+      child_support_deviation: true
+
+  - name: only party A short financial statement
+    family: financial
+    overrides:
+      financial_statement_scope: spouse_1_only
+      users[0].gross_annual_income: 74999
+
+  - name: only party B long financial statement
+    family: financial
+    overrides:
+      financial_statement_scope: spouse_2_only
+      users[1].gross_annual_income: 75000
+
+  - name: both short financial statements
+    family: financial
+    overrides:
+      financial_statement_scope: both
+      users[0].gross_annual_income: 0
+      users[1].gross_annual_income: 74999
+
+  - name: both long financial statements at upper boundary
+    family: financial
+    overrides:
+      financial_statement_scope: both
+      users[0].gross_annual_income: 75001
+      users[1].gross_annual_income: 75001
+
+  - name: party A self employment schedule
+    family: financial
+    overrides:
+      financial_statement_scope: spouse_1_only
+      users[0].gross_annual_income: 75000
+      users[0].has_self_employment_income: true
+      users[0].has_rental_income: false
+
+  - name: party B rental schedule
+    family: financial
+    overrides:
+      financial_statement_scope: spouse_2_only
+      users[1].gross_annual_income: 75000
+      users[1].has_self_employment_income: false
+      users[1].has_rental_income: true
+
+  - name: party A both schedules
+    family: financial
+    overrides:
+      financial_statement_scope: spouse_1_only
+      users[0].gross_annual_income: 75000
+      users[0].has_self_employment_income: true
+      users[0].has_rental_income: true
+
+  - name: fee waiver interview
+    family: fee_waiver
+    overrides:
+      ask_if_qualifies_for_fee_waiver: true
+
+  - name: uploaded marriage certificate
+    family: documents
+    overrides:
+      marriage_certificate_upload:
+        $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
+
+  - name: international marriage
+    family: relationship
+    overrides:
+      international_marriage: true
+
+  - name: previous divorce-related action
+    family: relationship
+    overrides:
+      previous_action: true
+
+cardinality_classes:
+  users: [2]
+  children: [0, 1, 2, 4, 5, 9]
+  other_care_custody_proceedings: [0, 1, 2]
+  child_previous_addresses: [0, 1, 2, 3]
+  proceeding_other_parties: [0, 1, 3, 4]
+  financial_lists: [0, 1, 2]
+
+representatives:
+  text: Test
+  area: Test details
+  email: test@example.com
+  phone: 6175550100
+  date: '2025-01-15'
+  integer: 1
+  number: 1
+  currency: 100
+
+numeric_boundaries:
+  users[i].gross_annual_income: [0, 74999, 75000, 75001]
+  number_of_children_eligible: [1, 2, 3, 4, 5, 6]
+
+hang_policy:
+  request_timeout_seconds: 60
+  scenario_timeout_seconds: 900
+  max_steps: 500
+  max_same_screen_consecutive: 3
+  max_same_state_visits: 2
+  download_task_timeout_seconds: 300
+
+pass_gate:
+  - every statically declared local question id is classified as reached or proven unreachable
+  - every modeled dimension value is exercised when reachable
+  - every observed screen transition is recorded
+  - every terminal outcome is classified
+  - no error screen, HTTP failure, repeated-state loop, step exhaustion, or timeout
+  - every generated bundle completes and contains the expected documents
+  - runtime package versions and image digest match the run manifest

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -36,6 +36,7 @@ dimensions:
   uploaded_agreement_addresses_child_support: [false, true]
   uploaded_agreement_child_support_deviation: [false, true]
   child_support_deviation: [false, true]
+  custody_case_participation: [no cases, know of, participated]
 
 default_variables:
   has_existing_1b_action: false
@@ -86,6 +87,7 @@ default_variables:
   marital_home.state: MA
   marital_home.zip: '02108'
   ask_if_qualifies_for_fee_waiver: false
+  custody_case_participation: no cases
 
 # These are the finite path archetypes. Each entry is a complete modeled path:
 # the generator overlays it on default_variables and the runtime ledger proves
@@ -227,6 +229,9 @@ modeled_paths:
         $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
       uploaded_agreement_addresses_child_support: true
       uploaded_agreement_child_support_deviation: false
+      custody_case_participation: participated
+    cardinalities:
+      other_care_custody_proceedings: 1
 
   - name: four children uploaded worksheet uploaded agreement deviation
     family: children
@@ -242,6 +247,11 @@ modeled_paths:
         $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
       uploaded_agreement_addresses_child_support: true
       uploaded_agreement_child_support_deviation: true
+      custody_case_participation: participated
+      other_care_custody_proceedings.there_is_another:
+        $sequence: [true, false]
+    cardinalities:
+      other_care_custody_proceedings: 2
 
   - name: five children built worksheet built agreement
     family: children
@@ -251,6 +261,9 @@ modeled_paths:
       csg_worksheet_path: interview
       separation_agreement_format: interview
       child_support_deviation: false
+      custody_case_participation: know of
+    cardinalities:
+      other_care_custody_proceedings: 1
 
   - name: nine children built worksheet built agreement deviation
     family: children
@@ -349,6 +362,9 @@ cardinality_probes:
   children:
     variable: children
     count_variable: children_of_marriage_number
+  other_care_custody_proceedings:
+    variable: other_care_custody_proceedings
+    default_count: 0
 
 representatives:
   text: Test

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -313,6 +313,13 @@ modeled_paths:
     cardinalities:
       other_care_custody_proceedings: 1
       proceeding_other_parties: [4]
+    probe_events:
+      - event: review_divorcejointpetition
+        expected_id: divorce joint petition review screen
+      - event: review_a_divorce_agreement
+        expected_id: review a divorce agreement
+      - event: children.revisit
+        expected_id: edit children
 
   - name: nine children built worksheet built agreement deviation
     family: children
@@ -322,6 +329,11 @@ modeled_paths:
       csg_worksheet_path: interview
       separation_agreement_format: interview
       child_support_deviation: true
+    probe_events:
+      - event: review_divorcejointpetition
+        expected_id: divorce joint petition review screen
+      - event: review_cjd_305
+        expected_id: review cjd_305
 
   - name: only party A short financial statement
     family: financial
@@ -330,6 +342,10 @@ modeled_paths:
       users[0].gross_annual_income: 74999
       users[0].has_self_employment_income: false
       users[0].has_rental_income: false
+      users[0].income_list.selected_types:
+        wages: true
+      users[0].expense_list.selected_types:
+        rent: true
     probe_events:
       - event: review_divorcejointpetition
         expected_id: divorce joint petition review screen
@@ -363,6 +379,8 @@ modeled_paths:
         expected_id: other_assets_revisit
       - event: users[0].liabilities.revisit
         expected_id: liabilities_revisit
+      - event: users.revisit
+        expected_id: edit users
 
   - name: only party B long financial statement
     family: financial
@@ -371,6 +389,10 @@ modeled_paths:
       users[1].gross_annual_income: 75000
       users[1].has_self_employment_income: false
       users[1].has_rental_income: false
+      users[1].income_list.selected_types:
+        wages: true
+      users[1].long_expense_list.selected_types:
+        rent: true
     probe_events:
       - event: review_divorcejointpetition
         expected_id: divorce joint petition review screen
@@ -456,6 +478,10 @@ modeled_paths:
       users[0].gross_annual_income: 75000
       users[0].has_self_employment_income: true
       users[0].has_rental_income: true
+      users[0].schedule_a_expenses.there_are_any: true
+      users[0].schedule_a_expenses.there_is_another: false
+      users[0].schedule_b_expenses.there_are_any: true
+      users[0].schedule_b_expenses.there_is_another: false
     probe_events:
       - event: review_divorcejointpetition
         expected_id: divorce joint petition review screen
@@ -516,6 +542,23 @@ modeled_paths:
       hh_income.value: 10000
       hh_income.times_per_year: 12
       can_afford: true
+
+  - name: fee waiver detailed income qualifies after reconciliation
+    family: fee_waiver
+    overrides:
+      ask_if_qualifies_for_fee_waiver: true
+      fee_waiver_qualifies: true
+      hh_income.value: 10000
+      hh_income.times_per_year: 12
+      can_afford: false
+      has_household_members: false
+      users[0].jobs.target_number: 1
+      users[0].jobs[0].is_hourly: false
+      users[0].jobs[0].times_per_year: 12
+      users[0].jobs[0].value: 100
+      users[0].jobs[0].deduction: 0
+      users[0].nonemployment.selected_types: {}
+      confirm_can_skip_supplement: true
 
   - name: multiple venue counties
     family: venue

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -495,10 +495,10 @@ hang_policy:
   max_steps: 500
   max_same_screen_consecutive: 3
   max_same_state_visits: 2
-  # Financial-statement PDF, DOCX, ZIP, and merged-PDF generation exceeded
-  # five minutes on the bounded CI runner without a worker crash. Keep a hard
-  # ten-minute ceiling so slow generation remains distinguishable from a hang.
-  download_task_timeout_seconds: 600
+  # The ten-document five-child packet completes in about 80 seconds on the
+  # bounded runner. Treat three minutes on the user-visible waiting screen as
+  # a failure while leaving more than twice that verified packet-build time.
+  download_task_timeout_seconds: 180
 
 pass_gate:
   - every statically declared local question id is classified as reached or proven unreachable

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -192,17 +192,35 @@ modeled_paths:
     overrides:
       users[0].has_attorney: true
       users[1].has_attorney: true
+    required_screen_ids:
+      - sign attorney for party A
+      - sign attorney for party B
+    forbidden_screen_ids:
+      - sign party A
+      - sign party B
 
   - name: only party A represented
     family: counsel
     overrides:
       users[0].has_attorney: true
+    required_screen_ids:
+      - sign attorney for party A
+      - sign party B
+    forbidden_screen_ids:
+      - sign party A
+      - sign attorney for party B
 
   - name: only party B represented
     family: counsel
     overrides:
       users[1].has_attorney: true
       who_lives_at_marital_home: party_b
+    required_screen_ids:
+      - sign party A
+      - sign attorney for party B
+    forbidden_screen_ids:
+      - sign attorney for party A
+      - sign party B
 
   - name: no agreement and unwilling to negotiate
     family: agreement

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -313,12 +313,16 @@ modeled_paths:
     overrides:
       financial_statement_scope: spouse_1_only
       users[0].gross_annual_income: 74999
+      users[0].has_self_employment_income: false
+      users[0].has_rental_income: false
 
   - name: only party B long financial statement
     family: financial
     overrides:
       financial_statement_scope: spouse_2_only
       users[1].gross_annual_income: 75000
+      users[1].has_self_employment_income: false
+      users[1].has_rental_income: false
 
   - name: both short financial statements
     family: financial
@@ -326,6 +330,10 @@ modeled_paths:
       financial_statement_scope: both
       users[0].gross_annual_income: 0
       users[1].gross_annual_income: 74999
+      users[0].has_self_employment_income: false
+      users[0].has_rental_income: false
+      users[1].has_self_employment_income: false
+      users[1].has_rental_income: false
       users[0].motor_vehicles.there_are_any: true
       users[0].pensions.there_are_any: true
       users[0].other_assets.there_are_any: true
@@ -342,6 +350,10 @@ modeled_paths:
       financial_statement_scope: both
       users[0].gross_annual_income: 75001
       users[1].gross_annual_income: 75001
+      users[0].has_self_employment_income: false
+      users[0].has_rental_income: false
+      users[1].has_self_employment_income: false
+      users[1].has_rental_income: false
       users[0].motor_vehicles.there_are_any: true
       users[0].motor_vehicles.there_is_another:
         $sequence: [true, false]

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -17,8 +17,9 @@ dimensions:
   massachusetts_residency: [false, true]
   couple_ever_lived_in_massachusetts: [false, true]
   breakdown_in_massachusetts: [false, true]
-  divorce_affirm: [false, true]
-  joint_petition_affirm: [false, true]
+  divorce_type_affirmations.want_divorce: [false, true]
+  divorce_type_affirmations.file_jointly: [false, true]
+  divorce_type_affirmations.will_notarize: [false, true]
   separation_agreement_reached: [false, true]
   parties_will_negotiate: [false, true]
   separation_agreement_format: [wait, upload, interview]
@@ -340,6 +341,14 @@ cardinality_classes:
   child_previous_addresses: [0, 1, 2, 3]
   proceeding_other_parties: [0, 1, 3, 4]
   financial_lists: [0, 1, 2]
+
+cardinality_probes:
+  users:
+    variable: users
+    fixed_count: 2
+  children:
+    variable: children
+    count_variable: children_of_marriage_number
 
 representatives:
   text: Test

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -483,7 +483,10 @@ hang_policy:
   max_steps: 500
   max_same_screen_consecutive: 3
   max_same_state_visits: 2
-  download_task_timeout_seconds: 300
+  # Financial-statement PDF, DOCX, ZIP, and merged-PDF generation exceeded
+  # five minutes on the bounded CI runner without a worker crash. Keep a hard
+  # ten-minute ceiling so slow generation remains distinguishable from a hang.
+  download_task_timeout_seconds: 600
 
 pass_gate:
   - every statically declared local question id is classified as reached or proven unreachable

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -643,25 +643,22 @@ modeled_paths:
       other_care_custody_proceedings: 1
 
   - name: agreement health insurance impasse
-    family: agreement_terminal
+    family: agreement
     overrides:
       separation_agreement_format: interview
       health_insurance_custom_terms_adult: false
-    expected_terminal_ids:
+    required_screen_ids:
       - health insurance no agreement exit
-    terminal_assertions: false
-    probe_events: []
 
   - name: agreement tax impasse
-    family: agreement_terminal
+    family: agreement
     overrides:
       separation_agreement_format: interview
       health_insurance_custom_terms_adult: true
       taxes_custom_terms: false
-    expected_terminal_ids:
+      taxes_file_separately: false
+    required_screen_ids:
       - taxes no agreement exit
-    terminal_assertions: false
-    probe_events: []
 
 cardinality_classes:
   users: [2]

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -88,6 +88,8 @@ default_variables:
   marital_home.zip: '02108'
   ask_if_qualifies_for_fee_waiver: false
   custody_case_participation: no cases
+  children[i].has_gal: false
+  children[i].gals.target_number: 0
 
 # These are the finite path archetypes. Each entry is a complete modeled path:
 # the generator overlays it on default_variables and the runtime ledger proves

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -33,6 +33,14 @@ dimensions:
   users[0].has_attorney: [false, true]
   users[1].has_attorney: [false, true]
   ask_if_qualifies_for_fee_waiver: [false, true]
+  fee_waiver_qualifies: [false, true]
+  health_insurance_custom_terms_adult: [false, true]
+  health_insurance_self_responsible: [false, true]
+  taxes_custom_terms: [false, true]
+  alimony_waived_all: [false, true]
+  alimony_payment_agreed: [false, true]
+  individual_debt_responsible_each: [false, true]
+  children[i].has_gal: [false, true]
   uploaded_agreement_addresses_child_support: [false, true]
   uploaded_agreement_child_support_deviation: [false, true]
   child_support_deviation: [false, true]
@@ -87,6 +95,13 @@ default_variables:
   marital_home.state: MA
   marital_home.zip: '02108'
   ask_if_qualifies_for_fee_waiver: false
+  fee_waiver_qualifies: true
+  health_insurance_custom_terms_adult: true
+  health_insurance_self_responsible: true
+  taxes_custom_terms: true
+  alimony_waived_all: true
+  alimony_payment_agreed: false
+  individual_debt_responsible_each: true
   custody_case_participation: no cases
   children[i].has_gal: false
   children[i].gals.target_number: 0
@@ -315,6 +330,39 @@ modeled_paths:
       users[0].gross_annual_income: 74999
       users[0].has_self_employment_income: false
       users[0].has_rental_income: false
+    probe_events:
+      - event: review_divorcejointpetition
+        expected_id: divorce joint petition review screen
+      - event: review_court_and_parties_fs
+        expected_id: review_court_and_parties_fs
+      - event: review_personal_information_fs
+        expected_id: review_personal_information_fs
+      - event: review_income_fs
+        expected_id: review_income_fs
+      - event: review_deductions_short_fs
+        expected_id: review_deductions_short_fs
+      - event: review_expenses_short_fs
+        expected_id: review_expenses_short_fs
+      - event: review_assets_short_fs
+        expected_id: review_assets_short_fs
+      - event: review_liabilities_short_fs
+        expected_id: review_liabilities_short_fs
+      - event: review_fs
+        expected_id: review_fs
+      - event: review_all_sections_fs
+        expected_id: review_all_sections_fs
+      - event: users[0].income_list.revisit
+        expected_id: fs_income_revisit
+      - event: users[0].expense_list.revisit
+        expected_id: fs_expense_revisit
+      - event: users[0].motor_vehicles.revisit
+        expected_id: motor_vehicles_revisit
+      - event: users[0].pensions.revisit
+        expected_id: pensions_revisit
+      - event: users[0].other_assets.revisit
+        expected_id: other_assets_revisit
+      - event: users[0].liabilities.revisit
+        expected_id: liabilities_revisit
 
   - name: only party B long financial statement
     family: financial
@@ -323,6 +371,19 @@ modeled_paths:
       users[1].gross_annual_income: 75000
       users[1].has_self_employment_income: false
       users[1].has_rental_income: false
+    probe_events:
+      - event: review_divorcejointpetition
+        expected_id: divorce joint petition review screen
+      - event: review_deductions_long_fs
+        expected_id: review_deductions_long_fs
+      - event: review_expenses_long_fs
+        expected_id: review_expenses_long_fs
+      - event: review_assets_long_fs
+        expected_id: review_assets_long_fs
+      - event: review_liabilities_long_fs
+        expected_id: review_liabilities_long_fs
+      - event: users[1].long_expense_list.revisit
+        expected_id: long_expense_revisit
 
   - name: both short financial statements
     family: financial
@@ -395,6 +456,17 @@ modeled_paths:
       users[0].gross_annual_income: 75000
       users[0].has_self_employment_income: true
       users[0].has_rental_income: true
+    probe_events:
+      - event: review_divorcejointpetition
+        expected_id: divorce joint petition review screen
+      - event: review_schedule_a_fs
+        expected_id: review_schedule_a_fs
+      - event: review_schedule_b_fs
+        expected_id: review_schedule_b_fs
+      - event: users[0].schedule_a_expenses.revisit
+        expected_id: schedule_a_expenses_revisit
+      - event: users[0].schedule_b_expenses.revisit
+        expected_id: schedule_b_expenses_revisit
 
   - name: fee waiver interview
     family: fee_waiver
@@ -418,6 +490,111 @@ modeled_paths:
     overrides:
       previous_action: true
       request_survive_agreement: false
+
+  - name: fee waiver detailed supplement
+    family: fee_waiver
+    overrides:
+      ask_if_qualifies_for_fee_waiver: true
+      fee_waiver_qualifies: true
+      hh_income.value: 10000
+      hh_income.times_per_year: 12
+      can_afford: false
+      users[0].jobs.target_number: 1
+      users[0].nonemployment.selected_types:
+        other: true
+      users[0].nonemployment[0].times_per_year: 12
+      users[0].nonemployment[0].value: 5000
+      household.target_number: 1
+      household[i].jobs.target_number: 1
+      users[0].accounts.there_are_any: true
+
+  - name: fee waiver does not qualify
+    family: fee_waiver
+    overrides:
+      ask_if_qualifies_for_fee_waiver: true
+      fee_waiver_qualifies: false
+      hh_income.value: 10000
+      hh_income.times_per_year: 12
+      can_afford: true
+
+  - name: multiple venue counties
+    family: venue
+    overrides:
+      who_lives_at_marital_home: neither
+      users[0].address.county: Suffolk
+      users[1].address.address: 225 Main Street
+      users[1].address.city: Worcester
+      users[1].address.county: Worcester
+      users[1].address.zip: '01608'
+
+  - name: multiple courts in Essex County
+    family: venue
+    overrides:
+      marital_home.address: 2 Federal Street
+      marital_home.city: Salem
+      marital_home.county: Essex
+      marital_home.zip: '01970'
+      users[0].address.address: 2 Federal Street
+      users[0].address.city: Salem
+      users[0].address.county: Essex
+      users[0].address.zip: '01970'
+      users[1].address.address: 2 Federal Street
+      users[1].address.city: Salem
+      users[1].address.county: Essex
+      users[1].address.zip: '01970'
+
+  - name: agreement insurance alimony and individual debts
+    family: agreement
+    overrides:
+      separation_agreement_format: interview
+      health_insurance_custom_terms_adult: true
+      health_insurance_self_responsible: false
+      health_insurance_with_cost_allowed: 'Yes'
+      alimony_waived_all: false
+      alimony_payment_agreed: true
+      individual_debt_responsible_each: false
+    probe_events:
+      - event: review_divorcejointpetition
+        expected_id: divorce joint petition review screen
+      - event: review_a_divorce_agreement
+        expected_id: review a divorce agreement
+
+  - name: adoption proceeding and appointed guardian
+    family: children
+    overrides:
+      children_of_marriage: true
+      children_of_marriage_number: 1
+      csg_worksheet_path: wait
+      custody_case_participation: participated
+      other_care_custody_proceedings[0].case_status: adoption
+      other_care_custody_proceedings[0].other_party_types:
+        other: false
+        dcf: false
+      children[i].has_gal: true
+      children[i].gals.target_number: 1
+    cardinalities:
+      other_care_custody_proceedings: 1
+
+  - name: agreement health insurance impasse
+    family: agreement_terminal
+    overrides:
+      separation_agreement_format: interview
+      health_insurance_custom_terms_adult: false
+    expected_terminal_ids:
+      - health insurance no agreement exit
+    terminal_assertions: false
+    probe_events: []
+
+  - name: agreement tax impasse
+    family: agreement_terminal
+    overrides:
+      separation_agreement_format: interview
+      health_insurance_custom_terms_adult: true
+      taxes_custom_terms: false
+    expected_terminal_ids:
+      - taxes no agreement exit
+    terminal_assertions: false
+    probe_events: []
 
 cardinality_classes:
   users: [2]

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -116,6 +116,12 @@ modeled_paths:
   - name: baseline no children agreement later
     family: baseline
     overrides: {}
+    required_screen_ids:
+      - sign party A
+      - sign party B
+    forbidden_screen_ids:
+      - sign attorney for party A
+      - sign attorney for party B
 
   - name: legal marriage warning
     family: eligibility

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -23,8 +23,12 @@ dimensions:
   parties_will_negotiate: [false, true]
   separation_agreement_format: [wait, upload, interview]
   csg_worksheet_path: [wait, upload, interview]
+  uploaded_worksheet_payor: [party_a, party_b]
   children_of_marriage: [false, true]
   previous_action: [false, true]
+  who_lives_at_marital_home: [both, party_a, party_b, neither]
+  request_merge_agreement: [false, true]
+  request_survive_agreement: [false, true]
   users[0].has_attorney: [false, true]
   users[1].has_attorney: [false, true]
   ask_if_qualifies_for_fee_waiver: [false, true]
@@ -47,18 +51,27 @@ default_variables:
   separation_agreement_reached: true
   separation_agreement_documented: false
   separation_agreement_format: wait
+  csg_worksheet_path: wait
+  uploaded_worksheet_payor: party_a
   uploaded_agreement_addresses_child_support: false
   uploaded_agreement_child_support_deviation: false
   child_support_deviation: false
   international_marriage: false
   previous_action: false
   who_lives_at_marital_home: both
+  request_merge_agreement: true
+  request_survive_agreement: true
   users[0].has_attorney: false
   users[1].has_attorney: false
   users[0].name.first: Alex
   users[0].name.last: Example
+  users[0].birthdate: '1985-01-15'
+  users[0].ssn: 123-45-6789
   users[1].name.first: Bailey
   users[1].name.last: Example
+  users[1].birthdate: '1987-01-15'
+  users[1].ssn: 987-65-4321
+  users[i].birthdate: '1985-01-15'
   users[0].address.address: 1 Main Street
   users[0].address.city: Boston
   users[0].address.state: MA
@@ -144,6 +157,7 @@ modeled_paths:
     overrides:
       has_existing_1b_action: true
       plaintiff_is_party_a: true
+      who_lives_at_marital_home: party_a
 
   - name: existing 1B party B plaintiff
     family: existing_case
@@ -166,6 +180,7 @@ modeled_paths:
     family: counsel
     overrides:
       users[1].has_attorney: true
+      who_lives_at_marital_home: party_b
 
   - name: no agreement and unwilling to negotiate
     family: agreement
@@ -185,6 +200,7 @@ modeled_paths:
     overrides:
       separation_agreement_documented: true
       separation_agreement_format: upload
+      request_merge_agreement: false
       separation_agreement_upload:
         $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
 
@@ -201,6 +217,7 @@ modeled_paths:
       children_of_marriage: true
       children_of_marriage_number: 2
       csg_worksheet_path: upload
+      uploaded_worksheet_payor: party_b
       child_support_guidelines_worksheet_upload:
         $file: docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf
       separation_agreement_documented: true
@@ -308,11 +325,13 @@ modeled_paths:
     family: relationship
     overrides:
       international_marriage: true
+      who_lives_at_marital_home: neither
 
   - name: previous divorce-related action
     family: relationship
     overrides:
       previous_action: true
+      request_survive_agreement: false
 
 cardinality_classes:
   users: [2]

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -473,7 +473,7 @@ numeric_boundaries:
   number_of_children_eligible: [1, 2, 3, 4, 5, 6]
 
 hang_policy:
-  runtime_workers: 2
+  runtime_workers: 1
   request_timeout_seconds: 60
   scenario_timeout_seconds: 900
   max_steps: 500

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -90,6 +90,8 @@ default_variables:
   custody_case_participation: no cases
   children[i].has_gal: false
   children[i].gals.target_number: 0
+  children[i].address.country: USA
+  children[i].address.start_date: '2024'
 
 # These are the finite path archetypes. Each entry is a complete modeled path:
 # the generator overlays it on default_variables and the runtime ledger proves

--- a/tests/certification/coverage_model.yml
+++ b/tests/certification/coverage_model.yml
@@ -213,6 +213,9 @@ modeled_paths:
       children_of_marriage: true
       children_of_marriage_number: 1
       csg_worksheet_path: wait
+      children[0].previous_addresses.there_are_any: true
+    cardinalities:
+      child_previous_addresses: [1]
 
   - name: two children uploaded worksheet uploaded agreement no deviation
     family: children
@@ -230,8 +233,16 @@ modeled_paths:
       uploaded_agreement_addresses_child_support: true
       uploaded_agreement_child_support_deviation: false
       custody_case_participation: participated
+      other_care_custody_proceedings[0].other_party_types:
+        other: true
+        dcf: false
+      children[0].previous_addresses.there_are_any: true
+      children[0].previous_addresses.there_is_another:
+        $sequence: [true, false]
     cardinalities:
       other_care_custody_proceedings: 1
+      child_previous_addresses: [2, 0]
+      proceeding_other_parties: [1]
 
   - name: four children uploaded worksheet uploaded agreement deviation
     family: children
@@ -250,8 +261,21 @@ modeled_paths:
       custody_case_participation: participated
       other_care_custody_proceedings.there_is_another:
         $sequence: [true, false]
+      other_care_custody_proceedings[0].other_party_types:
+        other: true
+        dcf: false
+      other_care_custody_proceedings[0].other_parties.there_is_another:
+        $sequence: [true, true, false]
+      other_care_custody_proceedings[1].other_party_types:
+        other: false
+        dcf: false
+      children[0].previous_addresses.there_are_any: true
+      children[0].previous_addresses.there_is_another:
+        $sequence: [true, true, false]
     cardinalities:
       other_care_custody_proceedings: 2
+      child_previous_addresses: [3, 0, 0, 0]
+      proceeding_other_parties: [3, 0]
 
   - name: five children built worksheet built agreement
     family: children
@@ -262,8 +286,14 @@ modeled_paths:
       separation_agreement_format: interview
       child_support_deviation: false
       custody_case_participation: know of
+      other_care_custody_proceedings[0].other_party_types:
+        other: true
+        dcf: false
+      other_care_custody_proceedings[0].other_parties.there_is_another:
+        $sequence: [true, true, true, false]
     cardinalities:
       other_care_custody_proceedings: 1
+      proceeding_other_parties: [4]
 
   - name: nine children built worksheet built agreement deviation
     family: children
@@ -292,6 +322,15 @@ modeled_paths:
       financial_statement_scope: both
       users[0].gross_annual_income: 0
       users[1].gross_annual_income: 74999
+      users[0].motor_vehicles.there_are_any: true
+      users[0].pensions.there_are_any: true
+      users[0].other_assets.there_are_any: true
+      users[0].liabilities.there_are_any: true
+    cardinalities:
+      financial_motor_vehicles: [1, 0]
+      financial_pensions: [1, 0]
+      financial_other_assets: [1, 0]
+      financial_liabilities: [1, 0]
 
   - name: both long financial statements at upper boundary
     family: financial
@@ -299,6 +338,23 @@ modeled_paths:
       financial_statement_scope: both
       users[0].gross_annual_income: 75001
       users[1].gross_annual_income: 75001
+      users[0].motor_vehicles.there_are_any: true
+      users[0].motor_vehicles.there_is_another:
+        $sequence: [true, false]
+      users[0].pensions.there_are_any: true
+      users[0].pensions.there_is_another:
+        $sequence: [true, false]
+      users[0].other_assets.there_are_any: true
+      users[0].other_assets.there_is_another:
+        $sequence: [true, false]
+      users[0].liabilities.there_are_any: true
+      users[0].liabilities.there_is_another:
+        $sequence: [true, false]
+    cardinalities:
+      financial_motor_vehicles: [2, 0]
+      financial_pensions: [2, 0]
+      financial_other_assets: [2, 0]
+      financial_liabilities: [2, 0]
 
   - name: party A self employment schedule
     family: financial
@@ -353,7 +409,10 @@ cardinality_classes:
   other_care_custody_proceedings: [0, 1, 2]
   child_previous_addresses: [0, 1, 2, 3]
   proceeding_other_parties: [0, 1, 3, 4]
-  financial_lists: [0, 1, 2]
+  financial_motor_vehicles: [0, 1, 2]
+  financial_pensions: [0, 1, 2]
+  financial_other_assets: [0, 1, 2]
+  financial_liabilities: [0, 1, 2]
 
 cardinality_probes:
   users:
@@ -364,6 +423,39 @@ cardinality_probes:
     count_variable: children_of_marriage_number
   other_care_custody_proceedings:
     variable: other_care_custody_proceedings
+    default_count: 0
+  child_previous_addresses:
+    variable: children[*].previous_addresses
+    when_variable: children_of_marriage
+    per_parent_count_variable: children_of_marriage_number
+    default_count: 0
+  proceeding_other_parties:
+    variable: other_care_custody_proceedings[*].other_parties
+    parent_cardinality: other_care_custody_proceedings
+    default_count: 0
+  financial_motor_vehicles:
+    variable: users[*].motor_vehicles
+    when_variable: financial_statement_scope
+    when_values: [both]
+    parent_cardinality: users
+    default_count: 0
+  financial_pensions:
+    variable: users[*].pensions
+    when_variable: financial_statement_scope
+    when_values: [both]
+    parent_cardinality: users
+    default_count: 0
+  financial_other_assets:
+    variable: users[*].other_assets
+    when_variable: financial_statement_scope
+    when_values: [both]
+    parent_cardinality: users
+    default_count: 0
+  financial_liabilities:
+    variable: users[*].liabilities
+    when_variable: financial_statement_scope
+    when_values: [both]
+    parent_cardinality: users
     default_count: 0
 
 representatives:

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -48,6 +48,61 @@ def expected_terminal_evidence(variables: dict) -> dict[str, bool]:
     }
 
 
+def expected_bundle_documents(variables: dict) -> dict[str, bool]:
+    """Return the exact generated-document membership for a modeled route."""
+    terminal = expected_terminal_evidence(variables)
+    scope = variables.get("financial_statement_scope", "neither")
+    selected_users = {
+        0: scope in ("both", "spouse_1_only"),
+        1: scope in ("both", "spouse_2_only"),
+    }
+    expected = {
+        "motion_to_amend_attachment": bool(variables.get("has_existing_1b_action")),
+        "divorcejointpetition_Post_interview_instructions": True,
+        "divorcejointpetition_attachment": True,
+        "affidavit_attachment": True,
+        "r408_attachment": terminal["include_r408"],
+        "jointmotiontofilemarriagecertificatelate_attachment": terminal[
+            "needs_late_marriage_certificate_motion"
+        ],
+        # This modeled fee-waiver route uses the harness's low-income answers
+        # and must finish with an indigency form in the packet.
+        "affidavitofindigency_attachment": bool(
+            variables.get("ask_if_qualifies_for_fee_waiver")
+        ),
+        "child_care_or_custody_disclosure_affidavit_next_steps": terminal[
+            "include_care_or_custody_affidavit"
+        ],
+        "affidavit_of_care_or_custody_attachment": terminal[
+            "include_care_or_custody_affidavit"
+        ],
+        "ma_child_support_guidelines_worksheet_attachment": terminal[
+            "include_child_support_guidelines_worksheet"
+        ],
+        "cjd_305_attachment": terminal["include_findings_and_determinations"],
+        "a_divorce_agreement_Post_interview_instructions": terminal[
+            "include_separation_agreement"
+        ],
+        "a_divorce_agreement_attachment": terminal["include_separation_agreement"],
+    }
+    for index, selected in selected_users.items():
+        income = variables.get(f"users[{index}].gross_annual_income", 0)
+        form_type = "long" if selected and float(income) >= 75000 else "short"
+        expected[f"users[{index}].financial_statement_short_attachment"] = (
+            selected and form_type == "short"
+        )
+        expected[f"users[{index}].financial_statement_long_attachment"] = (
+            selected and form_type == "long"
+        )
+        expected[f"users[{index}].financial_statement_schedule_a_attachment"] = (
+            selected and bool(variables.get(f"users[{index}].has_self_employment_income"))
+        )
+        expected[f"users[{index}].financial_statement_schedule_b_attachment"] = (
+            selected and bool(variables.get(f"users[{index}].has_rental_income"))
+        )
+    return expected
+
+
 def expected_cardinalities(
     model: dict,
     variables: dict,
@@ -104,6 +159,9 @@ def generate(model: dict, output: Path) -> list[Path]:
             ),
             "expected_terminal_evidence": path.get(
                 "expected_terminal_evidence", expected_terminal_evidence(variables)
+            ),
+            "expected_bundle_documents": path.get(
+                "expected_bundle_documents", expected_bundle_documents(variables)
             ),
             "expected_cardinalities": path.get(
                 "expected_cardinalities",

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -18,6 +18,36 @@ def slug(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
 
 
+def expected_terminal_evidence(variables: dict) -> dict[str, bool]:
+    children = bool(variables.get("children_of_marriage"))
+    existing_1b = bool(variables.get("has_existing_1b_action"))
+    financial_scope = variables.get("financial_statement_scope", "neither")
+    agreement_format = variables.get("separation_agreement_format", "wait")
+    worksheet_path = variables.get("csg_worksheet_path", "wait")
+    if not children or worksheet_path == "wait" or agreement_format == "wait":
+        findings = False
+    elif agreement_format == "interview":
+        findings = bool(variables.get("child_support_deviation"))
+    else:
+        findings = bool(
+            variables.get("uploaded_agreement_addresses_child_support")
+            and variables.get("uploaded_agreement_child_support_deviation")
+        )
+    return {
+        "include_r408": not existing_1b,
+        "include_care_or_custody_affidavit": children,
+        "include_child_support_guidelines_worksheet": children and worksheet_path == "interview",
+        "include_financial_statement": financial_scope != "neither",
+        "include_financial_statement_spouse_1": financial_scope in ("both", "spouse_1_only"),
+        "include_financial_statement_spouse_2": financial_scope in ("both", "spouse_2_only"),
+        "include_separation_agreement": agreement_format == "interview",
+        "include_findings_and_determinations": findings,
+        "needs_late_marriage_certificate_motion": not bool(
+            variables.get("marriage_certificate_upload")
+        ),
+    }
+
+
 def generate(model: dict, output: Path) -> list[Path]:
     output.mkdir(parents=True, exist_ok=True)
     for old in output.glob("*.json"):
@@ -34,6 +64,9 @@ def generate(model: dict, output: Path) -> list[Path]:
             "variables": variables,
             "expected_terminal_ids": path.get(
                 "expected_terminal_ids", model.get("default_terminal_ids", [])
+            ),
+            "expected_terminal_evidence": path.get(
+                "expected_terminal_evidence", expected_terminal_evidence(variables)
             ),
             "probe_events": path.get(
                 "probe_events", model.get("default_probe_events", [])

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -159,6 +159,8 @@ def generate(model: dict, output: Path) -> list[Path]:
             "expected_terminal_ids": path.get(
                 "expected_terminal_ids", model.get("default_terminal_ids", [])
             ),
+            "required_screen_ids": path.get("required_screen_ids", []),
+            "forbidden_screen_ids": path.get("forbidden_screen_ids", []),
             "terminal_assertions": terminal_assertions,
             "expected_terminal_evidence": path.get(
                 "expected_terminal_evidence",

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -8,7 +8,7 @@ import json
 import re
 from pathlib import Path
 
-import yaml
+from model_loader import load_model
 
 
 HERE = Path(__file__).resolve().parent
@@ -124,7 +124,7 @@ def main() -> int:
     parser.add_argument("--model", type=Path, default=HERE / "coverage_model.yml")
     parser.add_argument("--output", type=Path, default=HERE / "generated_scenarios")
     args = parser.parse_args()
-    paths = generate(yaml.safe_load(args.model.read_text()), args.output)
+    paths = generate(load_model(args.model), args.output)
     print(f"generated {len(paths)} modeled paths in {args.output}")
     return 0
 

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -69,6 +69,7 @@ def expected_bundle_documents(variables: dict) -> dict[str, bool]:
         # and must finish with an indigency form in the packet.
         "affidavitofindigency_attachment": bool(
             variables.get("ask_if_qualifies_for_fee_waiver")
+            and variables.get("fee_waiver_qualifies", True)
         ),
         "child_care_or_custody_disclosure_affidavit_next_steps": terminal[
             "include_care_or_custody_affidavit"
@@ -149,6 +150,7 @@ def generate(model: dict, output: Path) -> list[Path]:
     for index, path in enumerate(model.get("modeled_paths", []), start=1):
         variables = dict(defaults)
         variables.update(path.get("overrides", {}))
+        terminal_assertions = path.get("terminal_assertions", True)
         scenario = {
             "name": path["name"],
             "family": path["family"],
@@ -157,15 +159,20 @@ def generate(model: dict, output: Path) -> list[Path]:
             "expected_terminal_ids": path.get(
                 "expected_terminal_ids", model.get("default_terminal_ids", [])
             ),
+            "terminal_assertions": terminal_assertions,
             "expected_terminal_evidence": path.get(
-                "expected_terminal_evidence", expected_terminal_evidence(variables)
+                "expected_terminal_evidence",
+                expected_terminal_evidence(variables) if terminal_assertions else {},
             ),
             "expected_bundle_documents": path.get(
-                "expected_bundle_documents", expected_bundle_documents(variables)
+                "expected_bundle_documents",
+                expected_bundle_documents(variables) if terminal_assertions else {},
             ),
             "expected_cardinalities": path.get(
                 "expected_cardinalities",
-                expected_cardinalities(model, variables, path.get("cardinalities")),
+                expected_cardinalities(model, variables, path.get("cardinalities"))
+                if terminal_assertions
+                else {},
             ),
             "probe_events": path.get(
                 "probe_events", model.get("default_probe_events", [])

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -35,6 +35,9 @@ def generate(model: dict, output: Path) -> list[Path]:
             "expected_terminal_ids": path.get(
                 "expected_terminal_ids", model.get("default_terminal_ids", [])
             ),
+            "probe_events": path.get(
+                "probe_events", model.get("default_probe_events", [])
+            ),
         }
         destination = output / f"{index:03d}_{slug(path['name'])}.json"
         destination.write_text(json.dumps(scenario, indent=2, sort_keys=True) + "\n")

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -56,8 +56,22 @@ def expected_cardinalities(
     result = {}
     path_cardinalities = path_cardinalities or {}
     for name, probe in model.get("cardinality_probes", {}).items():
+        if probe.get("when_variable") and not variables.get(probe["when_variable"]):
+            continue
+        if probe.get("when_values") and variables.get(probe["when_variable"]) not in probe["when_values"]:
+            continue
         if name in path_cardinalities:
             count = path_cardinalities[name]
+        elif "parent_cardinality" in probe:
+            parent_count = result[probe["parent_cardinality"]]["expected"]
+            if isinstance(parent_count, list):
+                raise ValueError(f"parent cardinality for {name} must be scalar")
+            count = [probe["default_count"] for _ in range(parent_count)]
+        elif "per_parent_count_variable" in probe:
+            count = [
+                probe["default_count"]
+                for _ in range(int(variables[probe["per_parent_count_variable"]]))
+            ]
         elif "fixed_count" in probe:
             count = probe["fixed_count"]
         elif "count_variable" in probe:
@@ -66,7 +80,7 @@ def expected_cardinalities(
             count = probe["default_count"]
         result[name] = {
             "variable": probe["variable"],
-            "expected": int(count),
+            "expected": [int(item) for item in count] if isinstance(count, list) else int(count),
         }
     return result
 

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Materialize the finite modeled paths as deterministic JSON scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def generate(model: dict, output: Path) -> list[Path]:
+    output.mkdir(parents=True, exist_ok=True)
+    for old in output.glob("*.json"):
+        old.unlink()
+    written = []
+    defaults = model.get("default_variables", {})
+    for index, path in enumerate(model.get("modeled_paths", []), start=1):
+        variables = dict(defaults)
+        variables.update(path.get("overrides", {}))
+        scenario = {
+            "name": path["name"],
+            "family": path["family"],
+            "interview": model["entrypoint"],
+            "variables": variables,
+            "expected_terminal_ids": path.get(
+                "expected_terminal_ids", model.get("default_terminal_ids", [])
+            ),
+        }
+        destination = output / f"{index:03d}_{slug(path['name'])}.json"
+        destination.write_text(json.dumps(scenario, indent=2, sort_keys=True) + "\n")
+        written.append(destination)
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, default=HERE / "coverage_model.yml")
+    parser.add_argument("--output", type=Path, default=HERE / "generated_scenarios")
+    args = parser.parse_args()
+    paths = generate(yaml.safe_load(args.model.read_text()), args.output)
+    print(f"generated {len(paths)} modeled paths in {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -48,6 +48,20 @@ def expected_terminal_evidence(variables: dict) -> dict[str, bool]:
     }
 
 
+def expected_cardinalities(model: dict, variables: dict) -> dict:
+    result = {}
+    for name, probe in model.get("cardinality_probes", {}).items():
+        if "fixed_count" in probe:
+            count = probe["fixed_count"]
+        else:
+            count = variables[probe["count_variable"]]
+        result[name] = {
+            "variable": probe["variable"],
+            "expected": int(count),
+        }
+    return result
+
+
 def generate(model: dict, output: Path) -> list[Path]:
     output.mkdir(parents=True, exist_ok=True)
     for old in output.glob("*.json"):
@@ -67,6 +81,9 @@ def generate(model: dict, output: Path) -> list[Path]:
             ),
             "expected_terminal_evidence": path.get(
                 "expected_terminal_evidence", expected_terminal_evidence(variables)
+            ),
+            "expected_cardinalities": path.get(
+                "expected_cardinalities", expected_cardinalities(model, variables)
             ),
             "probe_events": path.get(
                 "probe_events", model.get("default_probe_events", [])

--- a/tests/certification/generate_scenarios.py
+++ b/tests/certification/generate_scenarios.py
@@ -48,13 +48,22 @@ def expected_terminal_evidence(variables: dict) -> dict[str, bool]:
     }
 
 
-def expected_cardinalities(model: dict, variables: dict) -> dict:
+def expected_cardinalities(
+    model: dict,
+    variables: dict,
+    path_cardinalities: dict | None = None,
+) -> dict:
     result = {}
+    path_cardinalities = path_cardinalities or {}
     for name, probe in model.get("cardinality_probes", {}).items():
-        if "fixed_count" in probe:
+        if name in path_cardinalities:
+            count = path_cardinalities[name]
+        elif "fixed_count" in probe:
             count = probe["fixed_count"]
-        else:
+        elif "count_variable" in probe:
             count = variables[probe["count_variable"]]
+        else:
+            count = probe["default_count"]
         result[name] = {
             "variable": probe["variable"],
             "expected": int(count),
@@ -83,7 +92,8 @@ def generate(model: dict, output: Path) -> list[Path]:
                 "expected_terminal_evidence", expected_terminal_evidence(variables)
             ),
             "expected_cardinalities": path.get(
-                "expected_cardinalities", expected_cardinalities(model, variables)
+                "expected_cardinalities",
+                expected_cardinalities(model, variables, path.get("cardinalities")),
             ),
             "probe_events": path.get(
                 "probe_events", model.get("default_probe_events", [])

--- a/tests/certification/model_loader.py
+++ b/tests/certification/model_loader.py
@@ -1,0 +1,48 @@
+"""Strict loader for the finite certification model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.resolver import BaseResolver
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects silently shadowed mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: UniqueKeyLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def load_model(path: Path) -> dict[str, Any]:
+    """Load a certification model without permitting ambiguous YAML."""
+
+    model = yaml.load(path.read_text(), Loader=UniqueKeyLoader)
+    if not isinstance(model, dict):
+        raise ValueError(f"certification model must be a mapping: {path}")
+    return model

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -309,12 +309,18 @@ def field_within_cardinalities(
 def resolve_generic(variable: str, sought: str) -> str:
     if not sought:
         return variable
-    if variable.startswith(("x.", "x[")):
-        object_name = re.split(r"[.[]", sought, maxsplit=1)[0]
-        index_match = re.search(r"\[(\d+)\]", sought)
-        if variable.startswith("x[i]") and index_match:
-            return f"{object_name}[{index_match.group(1)}]{variable[4:]}"
-        return object_name + variable[1:]
+    if variable.startswith("x[i]"):
+        suffix = variable[4:]
+        suffix_depth = suffix.count(".")
+        if suffix_depth and sought.count(".") >= suffix_depth:
+            element_name = sought.rsplit(".", suffix_depth)[0]
+            return element_name + suffix
+    if variable.startswith("x."):
+        suffix = variable[1:]
+        suffix_depth = suffix.count(".")
+        if suffix_depth and sought.count(".") >= suffix_depth:
+            object_name = sought.rsplit(".", suffix_depth)[0]
+            return object_name + suffix
 
     resolved = variable
     for iterator in re.findall(r"\[([a-z])\]", variable):

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -160,6 +160,7 @@ DEFAULTS = {
     "email": "test@example.com",
     "tel": "6175550100",
     "phone": "6175550100",
+    "ssn": "123-45-6789",
     "date": "2025-01-15",
     "integer": 1,
     "number": 1,
@@ -311,7 +312,12 @@ def build_answer(
     visible_names: set[str] = set()
     for field in fields:
         controller = field.get("show_if_var")
-        if not controller:
+        # The API can expose a Python expression (for example,
+        # ``not showifdef("users1_gender")``) in show_if_var. We can safely
+        # evaluate only a controller that is another submitted field on this
+        # screen. Unknown or expression-based controllers stay visible so the
+        # server, not the driver, remains the authority on their condition.
+        if not controller or controller not in answer:
             continue
         raw = field["variable"]
         resolved = resolve_generic(raw, sought)

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 import requests
+import yaml
 
 from model_loader import load_model
 
@@ -47,6 +48,20 @@ def question_source_file(question: dict[str, Any], interview: str) -> str:
     # Docassemble omits source_file for questions defined by the root
     # interview, so the resolved interview name is the authoritative fallback.
     return interview
+
+
+def source_document_fingerprint(question: dict[str, Any]) -> str | None:
+    """Fingerprint the exact YAML document that produced a runtime screen."""
+    source = question.get("source")
+    history = source.get("history") if isinstance(source, dict) else None
+    source_code = history.get("source_code") if isinstance(history, dict) else None
+    if not isinstance(source_code, str) or not source_code.strip():
+        return None
+    try:
+        document = yaml.safe_load(source_code)
+    except yaml.YAMLError:
+        document = source_code.strip()
+    return hashlib.sha256(canonical(document).encode()).hexdigest()[:16]
 
 
 def question_variable(question: dict[str, Any]) -> str:
@@ -736,6 +751,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 "event_list": question.get("event_list") or [],
                 "question_name": question.get("questionName"),
                 "source_file": question_source_file(question, interview),
+                "source_fingerprint": source_document_fingerprint(question),
                 "mandatory": bool(question.get("mandatory")),
             }
             if question.get("questionType") == "undefined_variable":

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -169,6 +169,79 @@ def serialized_collection_count(value: Any) -> int | None:
     return None
 
 
+def serialized_collection_elements(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        elements = value.get("elements")
+        if isinstance(elements, list):
+            return elements
+        if isinstance(elements, dict):
+            return list(elements.values())
+    return []
+
+
+def serialized_bundle_evidence(value: Any) -> dict[str, dict[str, Any]]:
+    """Compact a serialized ALDocumentBundle into generated-file evidence."""
+
+    def file_records(node: Any) -> list[dict[str, Any]]:
+        records: list[dict[str, Any]] = []
+        if isinstance(node, dict):
+            class_name = str(node.get("_class", ""))
+            if class_name.endswith("DAFile"):
+                records.append(
+                    {
+                        "filename": node.get("filename"),
+                        "extension": node.get("extension"),
+                        "ok": node.get("ok"),
+                        "pages": (node.get("file_info") or {}).get("pages")
+                        if isinstance(node.get("file_info"), dict)
+                        else None,
+                    }
+                )
+            for nested in node.values():
+                records.extend(file_records(nested))
+        elif isinstance(node, list):
+            for nested in node:
+                records.extend(file_records(nested))
+        return records
+
+    result: dict[str, dict[str, Any]] = {}
+    for document in serialized_collection_elements(value):
+        if not isinstance(document, dict):
+            continue
+        name = str(document.get("instanceName") or "<unnamed>")
+        cache = document.get("cache")
+        cached_enabled = cache.get("enabled") if isinstance(cache, dict) else None
+        if document.get("always_enabled") is True:
+            enabled = True
+        elif isinstance(cached_enabled, bool):
+            enabled = cached_enabled
+        elif isinstance(document.get("enabled"), bool):
+            enabled = document["enabled"]
+        else:
+            enabled = None
+        files = file_records(document.get("elements"))
+        # Final and preview collections can serialize the same physical file
+        # more than once; retain one deterministic record per visible shape.
+        unique_files = {
+            canonical(record): record
+            for record in files
+        }
+        result[name] = {
+            "enabled": enabled,
+            "generated": any(record.get("ok") is True for record in unique_files.values()),
+            "files": sorted(
+                unique_files.values(),
+                key=lambda record: (
+                    str(record.get("filename")),
+                    str(record.get("extension")),
+                ),
+            ),
+        }
+    return result
+
+
 def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[int] | None:
     """Count a serialized collection at a dotted path, with ``[*]`` fan-out."""
     values: list[Any] = [root]
@@ -786,7 +859,6 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 else:
                     terminal_variables = client.variables(interview, session, secret)
                     evidence_names = (
-                        "al_user_bundle",
                         "divorcejointpetition_downloads_ready",
                         "include_r408",
                         "include_care_or_custody_affidavit",
@@ -803,6 +875,30 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         for name in evidence_names
                         if name in terminal_variables
                     }
+                    result["bundle_evidence"] = serialized_bundle_evidence(
+                        terminal_variables.get("al_user_bundle")
+                    )
+                    expected_bundle = scenario.get("expected_bundle_documents", {})
+                    bundle_mismatches = {}
+                    for name, expected_generated in expected_bundle.items():
+                        observed_document = result["bundle_evidence"].get(name)
+                        observed_generated = bool(
+                            observed_document and observed_document.get("generated")
+                        )
+                        failed_files = [
+                            record
+                            for record in (observed_document or {}).get("files", [])
+                            if record.get("ok") is False
+                        ]
+                        if observed_generated != expected_generated or failed_files:
+                            bundle_mismatches[name] = {
+                                "expected_generated": expected_generated,
+                                "observed": observed_document,
+                            }
+                    if bundle_mismatches:
+                        result["failure"] = "bundle_document_mismatch"
+                        result["bundle_document_mismatches"] = bundle_mismatches
+                        break
                     result["cardinality_evidence"] = {}
                     cardinality_mismatches = {}
                     for name, probe in scenario.get("expected_cardinalities", {}).items():

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -9,6 +9,7 @@ It is the runtime half of the combined-interview coverage proof.
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 import hashlib
 import json
@@ -700,6 +701,26 @@ def load_limits(model_path: Path) -> Limits:
     )
 
 
+def write_ledger(path: Path, server: str, results: list[dict[str, Any]]) -> dict[str, Any]:
+    ledger = {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "server": server,
+        "results": results,
+        "summary": {
+            "scenarios": len(results),
+            "passed": sum(result["status"] == "pass" for result in results),
+            "failed": sum(result["status"] != "pass" for result in results),
+            "unique_screen_ids": len({
+                screen
+                for result in results
+                for screen in result["seen_screen_ids"]
+            }),
+        },
+    }
+    path.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n")
+    return ledger
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--server", default=os.environ.get("DA_SERVER_URL", ""))
@@ -712,24 +733,39 @@ def main() -> int:
         parser.error("--server and --api-key (or DA_SERVER_URL/DA_API_KEY) are required")
 
     limits = load_limits(args.model)
-    client = Client(args.server, args.api_key, limits.request_timeout)
+    model = yaml.safe_load(args.model.read_text())
+    workers = int(model["hang_policy"].get("runtime_workers", 1))
+    if workers < 1:
+        parser.error("hang_policy.runtime_workers must be at least 1")
     scenarios = [json.loads(path.read_text()) for path in sorted(args.scenarios.glob("*.json"))]
-    results = [run_scenario(client, scenario, limits) for scenario in scenarios]
-    ledger = {
-        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "server": args.server,
-        "results": results,
-        "summary": {
-            "scenarios": len(results),
-            "passed": sum(result["status"] == "pass" for result in results),
-            "failed": sum(result["status"] != "pass" for result in results),
-            "unique_screen_ids": len({screen for result in results for screen in result["seen_screen_ids"]}),
-        },
-    }
-    args.ledger.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n")
+    indexed_results: dict[int, dict[str, Any]] = {}
+
+    def run_indexed(index: int, scenario: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+        client = Client(args.server, args.api_key, limits.request_timeout)
+        return index, run_scenario(client, scenario, limits)
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [
+            executor.submit(run_indexed, index, scenario)
+            for index, scenario in enumerate(scenarios)
+        ]
+        for future in as_completed(futures):
+            index, result = future.result()
+            indexed_results[index] = result
+            print(
+                f"{result['status'].upper()} {result['name']}: "
+                f"{result.get('failure') or result.get('terminal_id')}",
+                flush=True,
+            )
+            write_ledger(
+                args.ledger,
+                args.server,
+                [indexed_results[item] for item in sorted(indexed_results)],
+            )
+
+    results = [indexed_results[index] for index in range(len(scenarios))]
+    ledger = write_ledger(args.ledger, args.server, results)
     print(json.dumps(ledger["summary"], sort_keys=True))
-    for result in results:
-        print(f"{result['status'].upper()} {result['name']}: {result.get('failure') or result.get('terminal_id')}")
     return 1 if ledger["summary"]["failed"] else 0
 
 

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from typing import Any
 
 import requests
-import yaml
+
+from model_loader import load_model
 
 
 HERE = Path(__file__).resolve().parent
@@ -734,7 +735,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
 
 
 def load_limits(model_path: Path) -> Limits:
-    model = yaml.safe_load(model_path.read_text())
+    model = load_model(model_path)
     policy = model["hang_policy"]
     return Limits(
         request_timeout=int(policy["request_timeout_seconds"]),
@@ -778,7 +779,7 @@ def main() -> int:
         parser.error("--server and --api-key (or DA_SERVER_URL/DA_API_KEY) are required")
 
     limits = load_limits(args.model)
-    model = yaml.safe_load(args.model.read_text())
+    model = load_model(args.model)
     workers = int(model["hang_policy"].get("runtime_workers", 1))
     if workers < 1:
         parser.error("hang_policy.runtime_workers must be at least 1")

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -37,6 +37,18 @@ def question_id(question: dict[str, Any]) -> str:
     return str(question.get("id") or question.get("questionName") or "<unnamed>")
 
 
+def question_source_file(question: dict[str, Any], interview: str) -> str:
+    """Return a compact, stable locator for the question's interview file."""
+    source = question.get("source")
+    if isinstance(source, dict):
+        history = source.get("history")
+        if isinstance(history, dict) and history.get("source_file"):
+            return str(history["source_file"])
+    # Docassemble omits source_file for questions defined by the root
+    # interview, so the resolved interview name is the authoritative fallback.
+    return interview
+
+
 def question_variable(question: dict[str, Any]) -> str:
     direct = str(
         question.get("question_variable_name")
@@ -723,7 +735,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 "fields": field_info(question),
                 "event_list": question.get("event_list") or [],
                 "question_name": question.get("questionName"),
-                "source": question.get("source"),
+                "source_file": question_source_file(question, interview),
                 "mandatory": bool(question.get("mandatory")),
             }
             if question.get("questionType") == "undefined_variable":

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -718,6 +718,7 @@ class Client:
         *,
         values: list[str] | None = None,
         counts: list[str] | None = None,
+        files: list[str] | None = None,
     ) -> dict[str, Any]:
         """Fetch a compact read-only snapshot without serializing the whole session."""
         payload = self._params(interview, session, secret)
@@ -726,7 +727,11 @@ class Client:
                 "action": "combined_certification_snapshot",
                 "read_only": 1,
                 "arguments": canonical(
-                    {"values": values or [], "counts": counts or []}
+                    {
+                        "values": values or [],
+                        "counts": counts or [],
+                        "files": files or [],
+                    }
                 ),
             }
         )
@@ -759,12 +764,11 @@ class Client:
             payload["event_list"] = canonical(event_list)
         if question_name:
             payload["question_name"] = question_name
-        # Save the submitted variables first, then fetch the resulting screen.
-        # Besides matching the API's explicit partial-update mode, this keeps
-        # the committed session available when next-screen assembly fails and
-        # lets GET /question report the underlying assembly exception instead
-        # of the opaque set-and-assemble wrapper error.
-        payload["question"] = 0
+        # Ordinary answers are saved before a separate question fetch. Uploads
+        # use the API's documented set-and-evaluate request so file persistence
+        # and any PDF-preview task are created within the same completed
+        # request, instead of evaluating immediately after a partial update.
+        payload["question"] = 1 if uploads else 0
         with ExitStack() as stack:
             files = {
                 name: stack.enter_context(open((HERE.parents[1] / relative).resolve(), "rb"))
@@ -777,6 +781,8 @@ class Client:
                 timeout=self.timeout,
             )
         response.raise_for_status()
+        if uploads:
+            return response.json()
         return self.question(interview, session, secret)
 
     def action(
@@ -884,6 +890,13 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 if expected_terminal_ids and qid not in expected_terminal_ids:
                     result["failure"] = "unexpected_terminal"
                     result["expected_terminal_ids"] = sorted(expected_terminal_ids)
+                elif not scenario.get("terminal_assertions", True):
+                    # Some modeled branches intentionally end on a child
+                    # interview's explanatory dead end. Reaching the declared
+                    # terminal is the proof; a final divorce packet cannot and
+                    # should not exist on that route.
+                    result["status"] = "pass"
+                    result["failure"] = None
                 else:
                     evidence_names = (
                         "divorcejointpetition_downloads_ready",
@@ -905,6 +918,12 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                             "expected_cardinalities", {}
                         ).items()
                     }
+                    uploaded_variable_names = sorted(
+                        name
+                        for name, modeled_value in variables.items()
+                        if isinstance(modeled_value, dict)
+                        and "$file" in modeled_value
+                    )
                     terminal_variables = client.snapshot(
                         interview,
                         session,
@@ -919,6 +938,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                             for paths in cardinality_paths.values()
                             for path in paths
                         ],
+                        files=uploaded_variable_names,
                     )
                     result["terminal_evidence"] = {
                         name: terminal_variables[name]
@@ -944,6 +964,20 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         if isinstance(download_evidence.get("bundle_files", []), list)
                         else [],
                     }
+                    result["uploaded_file_evidence"] = terminal_variables.get(
+                        "uploaded_files", {}
+                    )
+                    failed_uploads = {
+                        name: result["uploaded_file_evidence"].get(name)
+                        for name in uploaded_variable_names
+                        if not result["uploaded_file_evidence"].get(name, {}).get(
+                            "retrievable"
+                        )
+                    }
+                    if failed_uploads:
+                        result["failure"] = "uploaded_file_not_retrievable"
+                        result["failed_uploads"] = failed_uploads
+                        break
                     expected_bundle = scenario.get("expected_bundle_documents", {})
                     expected_enabled = {
                         name for name, expected in expected_bundle.items() if expected

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -708,7 +708,7 @@ class Client:
         payload = self._params(interview, session, secret)
         payload.update(
             {
-                "action": "combined certification snapshot",
+                "action": "combined_certification_snapshot",
                 "read_only": 1,
                 "arguments": canonical(
                     {"values": values or [], "counts": counts or []}

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -169,64 +169,6 @@ def serialized_collection_count(value: Any) -> int | None:
     return None
 
 
-def serialized_download_evidence(value: Any) -> dict[str, Any]:
-    """Compact the exact ``_downloadable_files`` produced by the background task."""
-
-    def file_records(node: Any) -> list[dict[str, Any]]:
-        records: list[dict[str, Any]] = []
-        if isinstance(node, dict):
-            if str(node.get("_class", "")).endswith("DAFile"):
-                records.append(
-                    {
-                        "filename": node.get("filename"),
-                        "extension": node.get("extension"),
-                        "ok": node.get("ok"),
-                        "pages": (node.get("file_info") or {}).get("pages")
-                        if isinstance(node.get("file_info"), dict)
-                        else None,
-                    }
-                )
-            for nested in node.values():
-                records.extend(file_records(nested))
-        elif isinstance(node, list):
-            for nested in node:
-                records.extend(file_records(nested))
-        return records
-
-    document_results = value[0] if isinstance(value, list) and value else []
-    documents = []
-    for document in document_results if isinstance(document_results, list) else []:
-        if not isinstance(document, dict):
-            continue
-        files = {canonical(record): record for record in file_records(document)}
-        documents.append(
-            {
-                "title": document.get("title"),
-                "files": sorted(
-                    files.values(),
-                    key=lambda record: (
-                        str(record.get("filename")),
-                        str(record.get("extension")),
-                    ),
-                ),
-            }
-        )
-    bundle_files = {
-        canonical(record): record
-        for record in file_records(value[1:] if isinstance(value, list) else [])
-    }
-    return {
-        "documents": documents,
-        "bundle_files": sorted(
-            bundle_files.values(),
-            key=lambda record: (
-                str(record.get("filename")),
-                str(record.get("extension")),
-            ),
-        ),
-    }
-
-
 def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[int] | None:
     """Count a serialized collection at a dotted path, with ``[*]`` fan-out."""
     values: list[Any] = [root]
@@ -955,7 +897,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         values=list(evidence_names)
                         + [
                             "combined_bundle_enabled_document_names",
-                            "combined_bundle_downloadable_files",
+                            "combined_bundle_download_evidence",
                         ],
                         counts=[
                             path
@@ -974,9 +916,19 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         )
                     )
                     result["bundle_enabled_documents"] = sorted(enabled_documents)
-                    result["bundle_download_evidence"] = serialized_download_evidence(
-                        terminal_variables.get("combined_bundle_downloadable_files")
+                    download_evidence = terminal_variables.get(
+                        "combined_bundle_download_evidence", {}
                     )
+                    if not isinstance(download_evidence, dict):
+                        download_evidence = {}
+                    result["bundle_download_evidence"] = {
+                        "documents": download_evidence.get("documents", [])
+                        if isinstance(download_evidence.get("documents", []), list)
+                        else [],
+                        "bundle_files": download_evidence.get("bundle_files", [])
+                        if isinstance(download_evidence.get("bundle_files", []), list)
+                        else [],
+                    }
                     expected_bundle = scenario.get("expected_bundle_documents", {})
                     expected_enabled = {
                         name for name, expected in expected_bundle.items() if expected
@@ -998,8 +950,8 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                     failed_downloads = [
                         document
                         for document in download_documents
-                        if not document["files"]
-                        or any(file.get("ok") is False for file in document["files"])
+                        if not document.get("files")
+                        or any(file.get("ok") is not True for file in document["files"])
                     ]
                     if len(download_documents) != len(expected_enabled):
                         bundle_mismatches["<download-count>"] = {

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -330,6 +330,7 @@ def field_info(question: dict[str, Any]) -> list[dict[str, Any]]:
                 "inputtype": field.get("inputtype") or field.get("input type") or datatype,
                 "choices": field.get("choices") or [],
                 "required": field.get("required", True),
+                "show_if_sign": field.get("show_if_sign", 1),
                 "show_if_var": field.get("show_if_var") or "",
                 "show_if_val": field.get("show_if_val"),
             }
@@ -601,7 +602,12 @@ def build_answer(
         send_name = raw if raw.startswith(("x.", "x[")) else resolved
         controller_value = answer.get(controller)
         expected = field.get("show_if_val")
-        visible = show_if_matches(controller_value, expected)
+        condition_matches = show_if_matches(controller_value, expected)
+        visible = (
+            condition_matches
+            if field.get("show_if_sign", 1)
+            else not condition_matches
+        )
         (visible_names if visible else hidden_names).add(send_name)
     for send_name in hidden_names - visible_names:
         # POST /api/session assigns variables directly; it does not execute a

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -9,6 +9,7 @@ It is the runtime half of the combined-interview coverage proof.
 from __future__ import annotations
 
 import argparse
+import copy
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 import hashlib
@@ -186,6 +187,78 @@ def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[i
     return counts[0] if counts else None
 
 
+def serialized_path_value(root: dict[str, Any], path: str) -> Any:
+    """Return a value from Docassemble's nested serialized object format."""
+    value: Any = root
+    for part in path.split("."):
+        match = re.fullmatch(r"([^\[]+)(?:\[(\d+)\])?", part)
+        if not match or not isinstance(value, dict):
+            return None
+        name, index = match.groups()
+        if name not in value:
+            return None
+        value = value[name]
+        if index is not None:
+            elements = value.get("elements") if isinstance(value, dict) else value
+            if isinstance(elements, list) and int(index) < len(elements):
+                value = elements[int(index)]
+            elif isinstance(elements, dict) and index in elements:
+                value = elements[index]
+            else:
+                return None
+    return value
+
+
+def field_within_cardinalities(
+    variable: str,
+    expected_cardinalities: dict[str, dict[str, Any]] | None,
+) -> bool:
+    """Reject rendered list-collect rows beyond the scenario's finite model."""
+    concrete_parts = [
+        re.fullmatch(r"([^\[]+)(?:\[(\d+)\])?", part)
+        for part in variable.split(".")
+    ]
+    if any(part is None for part in concrete_parts):
+        return True
+    concrete = [(part.group(1), part.group(2)) for part in concrete_parts if part]
+    for probe in (expected_cardinalities or {}).values():
+        expected = probe["expected"]
+        probe_parts = [
+            re.fullmatch(r"([^\[]+)(?:\[(\*)\])?", part)
+            for part in probe["variable"].split(".")
+        ]
+        if any(part is None for part in probe_parts) or len(concrete) < len(probe_parts):
+            continue
+        wildcard_indexes: list[int] = []
+        matches = True
+        for position, part in enumerate(probe_parts):
+            assert part is not None
+            name, wildcard = part.groups()
+            concrete_name, concrete_index = concrete[position]
+            if name != concrete_name:
+                matches = False
+                break
+            if wildcard:
+                if concrete_index is None:
+                    matches = False
+                    break
+                wildcard_indexes.append(int(concrete_index))
+        if not matches:
+            continue
+        element_index = concrete[len(probe_parts) - 1][1]
+        if element_index is None:
+            continue
+        if isinstance(expected, list):
+            if not wildcard_indexes or wildcard_indexes[-1] >= len(expected):
+                return False
+            limit = int(expected[wildcard_indexes[-1]])
+        else:
+            limit = int(expected)
+        if int(element_index) >= limit:
+            return False
+    return True
+
+
 def resolve_generic(variable: str, sought: str) -> str:
     if not sought:
         return variable
@@ -244,6 +317,9 @@ DEFAULTS = {
     "noyes": False,
     "noyesradio": False,
     "noyeswide": False,
+    "yesnomaybe": False,
+    "noyesmaybe": False,
+    "threestate": False,
     "signature": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
 }
 
@@ -281,6 +357,59 @@ def serialized_checkboxes(resolved: str, choices: list[Any], selected: Any) -> d
     }
 
 
+def serialized_object_choices(
+    resolved: str,
+    choices: list[Any],
+    selected: Any,
+    current_variables: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Serialize selected object references as the DAList expected by the API."""
+    if isinstance(selected, dict):
+        selected_names = [str(key) for key, value in selected.items() if value]
+    elif isinstance(selected, (list, tuple, set)):
+        selected_names = [str(value) for value in selected]
+    elif selected in (None, False, ""):
+        selected_names = []
+    else:
+        selected_names = [str(selected)]
+
+    available = {
+        str(choice.get("value")): choice
+        for choice in choices
+        if isinstance(choice, dict) and choice.get("value") is not None
+    }
+    unknown = [name for name in selected_names if name not in available]
+    if unknown:
+        raise ValueError(f"object selection for {resolved} contains unknown choices: {unknown}")
+    if current_variables is None:
+        raise ValueError(f"object selection for {resolved} requires current session variables")
+
+    template = serialized_path_value(current_variables, resolved)
+    if isinstance(template, dict) and template.get("_class"):
+        result = copy.deepcopy(template)
+    else:
+        result = {
+            "_class": "docassemble.base.util.DAList",
+            "instanceName": resolved,
+        }
+    elements = []
+    for name in selected_names:
+        source = serialized_path_value(current_variables, name)
+        if not isinstance(source, dict) or not source.get("_class"):
+            raise ValueError(f"object choice {name} is absent from current session variables")
+        elements.append(copy.deepcopy(source))
+    result.update(
+        {
+            "elements": elements,
+            "auto_gather": False,
+            "gathered": True,
+            "there_are_any": bool(elements),
+            "there_is_another": False,
+        }
+    )
+    return result
+
+
 def scenario_value(
     variables: dict[str, Any],
     resolved: str,
@@ -316,6 +445,7 @@ def answer_for_field(
     resolved: str,
     variables: dict[str, Any],
     sequence_positions: dict[str, int] | None = None,
+    current_variables: dict[str, Any] | None = None,
 ) -> Any:
     found, value = scenario_value(
         variables,
@@ -325,6 +455,9 @@ def answer_for_field(
     )
     if found:
         pass
+    elif field["datatype"] in {"object_checkboxes", "object_multiselect"}:
+        first = first_choice(field["choices"])
+        value = [] if first is None else [first]
     elif field["datatype"] == "file":
         value = ""
     elif field["datatype"] == "checkboxes":
@@ -339,6 +472,13 @@ def answer_for_field(
         value = DEFAULTS.get(str(field["inputtype"]), DEFAULTS.get(str(field["datatype"]), "Test"))
     if field["datatype"] == "checkboxes":
         return serialized_checkboxes(resolved, field["choices"], value)
+    if field["datatype"] in {"object_checkboxes", "object_multiselect"}:
+        return serialized_object_choices(
+            resolved,
+            field["choices"],
+            value,
+            current_variables,
+        )
     return value
 
 
@@ -354,6 +494,8 @@ def build_answer(
     question: dict[str, Any],
     scenario_variables: dict[str, Any],
     sequence_positions: dict[str, int] | None = None,
+    expected_cardinalities: dict[str, dict[str, Any]] | None = None,
+    current_variables: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     sought = question_variable(question)
     answer: dict[str, Any] = {}
@@ -362,6 +504,8 @@ def build_answer(
     for field in fields:
         raw = field["variable"]
         resolved = resolve_generic(raw, sought)
+        if not field_within_cardinalities(resolved, expected_cardinalities):
+            continue
         send_name = raw if raw.startswith(("x.", "x[")) else resolved
         if question.get("questionType") == "settrue":
             answer[send_name] = scenario_variables.get(
@@ -374,6 +518,7 @@ def build_answer(
                     resolved,
                     scenario_variables,
                     sequence_positions,
+                    current_variables,
                 )
             answer[send_name] = field_values[send_name]
 
@@ -578,6 +723,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 "fields": field_info(question),
                 "event_list": question.get("event_list") or [],
                 "question_name": question.get("questionName"),
+                "source": question.get("source"),
                 "mandatory": bool(question.get("mandatory")),
             }
             if question.get("questionType") == "undefined_variable":
@@ -647,9 +793,9 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                             "expected": probe["expected"],
                             "observed": observed_count,
                         }
-                        if observed_count is None and probe["expected"] == 0:
-                            observed_count = 0
-                            result["cardinality_evidence"][name]["observed"] = 0
+                        if observed_count is None and probe["expected"] in (0, []):
+                            observed_count = copy.deepcopy(probe["expected"])
+                            result["cardinality_evidence"][name]["observed"] = observed_count
                         if observed_count != probe["expected"]:
                             cardinality_mismatches[name] = result["cardinality_evidence"][name]
                     if cardinality_mismatches:
@@ -701,7 +847,26 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         result["failure"] = None
                 break
 
-            answer = build_answer(question, variables, sequence_positions)
+            needs_current_variables = any(
+                field["datatype"] in {"object_checkboxes", "object_multiselect"}
+                and field_within_cardinalities(
+                    resolve_generic(field["variable"], question_variable(question)),
+                    scenario.get("expected_cardinalities"),
+                )
+                for field in field_info(question)
+            )
+            current_variables = (
+                client.variables(interview, session, secret)
+                if needs_current_variables
+                else None
+            )
+            answer = build_answer(
+                question,
+                variables,
+                sequence_positions,
+                scenario.get("expected_cardinalities"),
+                current_variables,
+            )
             step["answer"] = answer
             # A repeated list-control screen is legitimate when a declared
             # sequence is advancing. Include the answer and sequence cursor in

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -540,6 +540,16 @@ def scenario_value(
     return False, None
 
 
+def scenario_has_value(variables: dict[str, Any], resolved: str, raw: str) -> bool:
+    """Return whether a scenario explicitly models a field without consuming sequences."""
+    return any(
+        key in variables
+        for key in dict.fromkeys(
+            (resolved, raw, normalized_variable(resolved), normalized_variable(raw))
+        )
+    )
+
+
 def answer_for_field(
     field: dict[str, Any],
     resolved: str,
@@ -644,6 +654,34 @@ def build_answer(
         visible = show_if_matches(controller_value, expected)
         (visible_names if visible else hidden_names).add(send_name)
     for send_name in hidden_names - visible_names:
+        # POST /api/session assigns variables directly; it does not execute a
+        # browser form's validation code. Preserve an explicitly modeled
+        # hidden field when that field is the exact variable Docassemble is
+        # seeking, so the API traversal can satisfy the same invariant that a
+        # browser submission would establish in validation code.
+        matching_field = next(
+            (
+                field
+                for field in fields
+                if (
+                    field["variable"]
+                    if field["variable"].startswith(("x.", "x["))
+                    else resolve_generic(field["variable"], sought)
+                )
+                == send_name
+            ),
+            None,
+        )
+        if (
+            send_name == sought
+            and matching_field is not None
+            and scenario_has_value(
+                scenario_variables,
+                send_name,
+                matching_field["variable"],
+            )
+        ):
+            continue
         answer.pop(send_name, None)
 
     field_names = {
@@ -1038,6 +1076,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
         result["failure"] = "http_error"
         result["exception"] = str(exc)
         if getattr(exc, "response", None) is not None:
+            result["response_status_code"] = exc.response.status_code
             result["response"] = exc.response.text[:2000]
     except Exception as exc:  # strict ledger: unexpected harness errors also fail
         result["failure"] = "driver_exception"

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Drive modeled paths through Docassemble and emit a machine-readable ledger.
+
+This is intentionally strict. Unknown runtime states, error screens, repeated
+states, request timeouts, wall-clock timeouts, and step exhaustion are failures.
+It is the runtime half of the combined-interview coverage proof.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import ExitStack
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+import yaml
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def question_id(question: dict[str, Any]) -> str:
+    return str(question.get("id") or question.get("questionName") or "<unnamed>")
+
+
+def question_variable(question: dict[str, Any]) -> str:
+    return str(
+        question.get("question_variable_name")
+        or question.get("continue_button_field")
+        or question.get("continueButtonField")
+        or ""
+    )
+
+
+def question_fingerprint(question: dict[str, Any]) -> str:
+    fields = []
+    for field in question.get("fields", []) or []:
+        fields.append(
+            {
+                "variable": field.get("variable_name") or field.get("variable"),
+                "datatype": field.get("datatype"),
+                "inputtype": field.get("inputtype"),
+                "choices": field.get("choices"),
+            }
+        )
+    payload = {
+        "id": question_id(question),
+        "type": question.get("questionType"),
+        "variable": question_variable(question),
+        "fields": fields,
+        "event_list": question.get("event_list"),
+    }
+    return hashlib.sha256(canonical(payload).encode()).hexdigest()[:16]
+
+
+def normalized_variable(value: Any) -> str:
+    return re.sub(r"\[\d+\]", "[i]", str(value or ""))
+
+
+def screen_variant_fingerprint(question: dict[str, Any]) -> str:
+    fields = [
+        {
+            "variable": normalized_variable(field.get("variable_name") or field.get("variable")),
+            "datatype": field.get("datatype"),
+            "inputtype": field.get("inputtype"),
+        }
+        for field in question.get("fields", []) or []
+    ]
+    payload = {
+        "id": question_id(question),
+        "type": question.get("questionType"),
+        "variable": normalized_variable(question_variable(question)),
+        "fields": fields,
+    }
+    return hashlib.sha256(canonical(payload).encode()).hexdigest()[:16]
+
+
+def display_text(question: dict[str, Any]) -> str:
+    return " ".join(
+        str(question.get(key, ""))
+        for key in ("questionText", "question", "subquestionText", "subquestion")
+    ).lower()
+
+
+def is_error(question: dict[str, Any]) -> bool:
+    text = display_text(question)
+    markers = (
+        "there was an error", "an error occurred", "internal server error",
+        "traceback", "nameerror", "attributeerror", "typeerror", "keyerror",
+        "indexerror", "maximum recursion", "infinite loop",
+    )
+    if any(marker in text for marker in markers):
+        return True
+    return question.get("questionType") == "undefined_variable"
+
+
+def is_terminal(question: dict[str, Any]) -> bool:
+    qid = question_id(question).lower()
+    qtype = str(question.get("questionType", "")).lower()
+    if qtype in {"exit", "restart", "deadend"}:
+        return True
+    if "download" in qid and not question.get("fields"):
+        return True
+    return False
+
+
+def is_download_waiting_screen(question: dict[str, Any]) -> bool:
+    qid = question_id(question).lower()
+    events = {str(item).lower() for item in question.get("event_list", []) or []}
+    return qid == "waiting screen" or "al_download_waiting_screen" in events
+
+
+def resolve_generic(variable: str, sought: str) -> str:
+    if not variable.startswith(("x.", "x[")) or not sought:
+        return variable
+    object_name = re.split(r"[.[]", sought, maxsplit=1)[0]
+    index_match = re.search(r"\[(\d+)\]", sought)
+    if variable.startswith("x[i]") and index_match:
+        return f"{object_name}[{index_match.group(1)}]{variable[4:]}"
+    return object_name + variable[1:]
+
+
+def field_info(question: dict[str, Any]) -> list[dict[str, Any]]:
+    result = []
+    for field in question.get("fields", []) or []:
+        datatype = field.get("datatype", "text")
+        if datatype in {"note", "html", "raw"}:
+            continue
+        variable = field.get("variable_name") or field.get("variable") or ""
+        if not variable:
+            continue
+        result.append(
+            {
+                "variable": str(variable),
+                "datatype": datatype,
+                "inputtype": field.get("inputtype") or field.get("input type") or datatype,
+                "choices": field.get("choices") or [],
+                "required": field.get("required", True),
+                "show_if_var": field.get("show_if_var") or "",
+                "show_if_val": field.get("show_if_val"),
+            }
+        )
+    return result
+
+
+DEFAULTS = {
+    "text": "Test",
+    "area": "Test details",
+    "email": "test@example.com",
+    "tel": "6175550100",
+    "phone": "6175550100",
+    "date": "2025-01-15",
+    "integer": 1,
+    "number": 1,
+    "currency": 100,
+    "yesno": True,
+    "yesnoradio": True,
+    "yesnowide": True,
+    "boolean": True,
+    "noyes": False,
+    "noyesradio": False,
+    "noyeswide": False,
+    "signature": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+}
+
+
+def first_choice(choices: list[Any]) -> Any:
+    if not choices:
+        return None
+    choice = choices[0]
+    if isinstance(choice, dict):
+        return choice.get("value", choice.get("label", next(iter(choice.values()), None)))
+    if isinstance(choice, list):
+        return choice[0] if choice else None
+    return choice
+
+
+def serialized_checkboxes(resolved: str, choices: list[Any], selected: Any) -> dict[str, Any]:
+    selected = selected if isinstance(selected, dict) else {}
+    elements: dict[str, bool] = {}
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        variable = str(choice.get("variable_name", ""))
+        match = re.search(r"\['([^']+)'\]", variable)
+        key = match.group(1) if match else choice.get("value")
+        if key is not None:
+            elements[str(key)] = bool(selected.get(str(key), False))
+    if not elements:
+        elements = {str(key): bool(value) for key, value in selected.items()}
+    return {
+        "_class": "docassemble.base.util.DADict",
+        "instanceName": resolved,
+        "elements": elements,
+        "auto_gather": False,
+        "gathered": True,
+    }
+
+
+def answer_for_field(field: dict[str, Any], resolved: str, variables: dict[str, Any]) -> Any:
+    if resolved in variables:
+        value = variables[resolved]
+    elif field["variable"] in variables:
+        value = variables[field["variable"]]
+    elif field["datatype"] == "file":
+        value = ""
+    elif field["datatype"] == "checkboxes":
+        value = {}
+    elif field["choices"]:
+        value = first_choice(field["choices"])
+    else:
+        value = DEFAULTS.get(str(field["inputtype"]), DEFAULTS.get(str(field["datatype"]), "Test"))
+    if field["datatype"] == "checkboxes":
+        return serialized_checkboxes(resolved, field["choices"], value)
+    return value
+
+
+def show_if_matches(actual: Any, expected: Any) -> bool:
+    if expected is None:
+        return bool(actual)
+    if isinstance(actual, (bool, int, float)) or isinstance(expected, (bool, int, float)):
+        return str(actual).lower() == str(expected).lower()
+    return actual == expected
+
+
+def build_answer(question: dict[str, Any], scenario_variables: dict[str, Any]) -> dict[str, Any]:
+    sought = question_variable(question)
+    answer: dict[str, Any] = {}
+    fields = field_info(question)
+    for field in fields:
+        raw = field["variable"]
+        resolved = resolve_generic(raw, sought)
+        send_name = raw if raw.startswith(("x.", "x[")) else resolved
+        answer[send_name] = answer_for_field(field, resolved, scenario_variables)
+
+    # Do not submit fields hidden by a simple same-screen show-if condition.
+    for field in fields:
+        controller = field.get("show_if_var")
+        if not controller:
+            continue
+        raw = field["variable"]
+        resolved = resolve_generic(raw, sought)
+        send_name = raw if raw.startswith(("x.", "x[")) else resolved
+        controller_value = answer.get(controller)
+        expected = field.get("show_if_val")
+        visible = show_if_matches(controller_value, expected)
+        if not visible:
+            answer.pop(send_name, None)
+
+    field_names = {
+        resolve_generic(field["variable"], sought)
+        for field in fields
+    } | {field["variable"] for field in fields}
+    if sought and sought not in field_names:
+        answer[sought] = scenario_variables.get(sought, True)
+    if not answer:
+        normalized_id = question_id(question).replace(" ", "_").replace("-", "_")
+        answer[normalized_id] = scenario_variables.get(normalized_id, True)
+    return answer
+
+
+@dataclass
+class Limits:
+    request_timeout: int
+    scenario_timeout: int
+    max_steps: int
+    max_same_screen: int
+    max_same_state_visits: int
+    download_task_timeout: int
+
+
+class Client:
+    def __init__(self, server: str, api_key: str, timeout: int):
+        self.server = server.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self.http = requests.Session()
+
+    def _params(self, interview: str, session: str, secret: str = "") -> dict[str, Any]:
+        result = {"key": self.api_key, "i": interview, "session": session}
+        if secret:
+            result["secret"] = secret
+        return result
+
+    def new_session(self, interview: str) -> tuple[str, str, str]:
+        response = self.http.get(
+            f"{self.server}/api/session/new",
+            params={"key": self.api_key, "i": interview},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["session"], data.get("secret", ""), data.get("i", interview)
+
+    def question(self, interview: str, session: str, secret: str) -> dict[str, Any]:
+        response = self.http.get(
+            f"{self.server}/api/session/question",
+            params=self._params(interview, session, secret),
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def answer(
+        self,
+        interview: str,
+        session: str,
+        secret: str,
+        variables: dict[str, Any],
+        event_list: list[str] | None = None,
+    ) -> dict[str, Any]:
+        payload = self._params(interview, session, secret)
+        uploads = {
+            name: value["$file"]
+            for name, value in variables.items()
+            if isinstance(value, dict) and "$file" in value
+        }
+        ordinary_variables = {name: value for name, value in variables.items() if name not in uploads}
+        payload["variables"] = canonical(ordinary_variables)
+        if event_list:
+            payload["event_list"] = canonical(event_list)
+        with ExitStack() as stack:
+            files = {
+                name: stack.enter_context(open((HERE.parents[1] / relative).resolve(), "rb"))
+                for name, relative in uploads.items()
+            }
+            response = self.http.post(
+                f"{self.server}/api/session",
+                data=payload,
+                files=files or None,
+                timeout=self.timeout,
+            )
+        response.raise_for_status()
+        return response.json()
+
+    def delete(self, interview: str, session: str, secret: str) -> None:
+        try:
+            self.http.delete(
+                f"{self.server}/api/session",
+                data=self._params(interview, session, secret),
+                timeout=min(self.timeout, 10),
+            )
+        except requests.RequestException:
+            pass
+
+
+def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> dict[str, Any]:
+    started = time.monotonic()
+    interview = scenario["interview"]
+    variables = scenario.get("variables", {})
+    result: dict[str, Any] = {
+        "name": scenario["name"],
+        "interview": interview,
+        "status": "fail",
+        "failure": None,
+        "steps": [],
+        "seen_screen_ids": [],
+    }
+    session = secret = ""
+    try:
+        session, secret, interview = client.new_session(interview)
+        state_visits: dict[str, int] = {}
+        previous_state = ""
+        consecutive = 0
+        download_wait_started: float | None = None
+        for step_number in range(1, limits.max_steps + 1):
+            if time.monotonic() - started > limits.scenario_timeout:
+                result["failure"] = "scenario_timeout"
+                break
+            question = client.question(interview, session, secret)
+            qid = question_id(question)
+            fingerprint = question_fingerprint(question)
+            state_visits[fingerprint] = state_visits.get(fingerprint, 0) + 1
+            consecutive = consecutive + 1 if fingerprint == previous_state else 1
+            previous_state = fingerprint
+            step = {
+                "number": step_number,
+                "id": qid,
+                "type": question.get("questionType"),
+                "fingerprint": fingerprint,
+                "variant_fingerprint": screen_variant_fingerprint(question),
+                "sought": question_variable(question),
+                "fields": field_info(question),
+                "event_list": question.get("event_list") or [],
+            }
+            if question.get("questionType") == "undefined_variable":
+                step["undefined_variable"] = question.get("variable")
+            if question.get("message_log"):
+                step["message_log"] = question.get("message_log")
+            result["steps"].append(step)
+            if qid not in result["seen_screen_ids"]:
+                result["seen_screen_ids"].append(qid)
+
+            if is_error(question):
+                result["failure"] = "error_screen"
+                step["text"] = display_text(question)[:1000]
+                break
+            if is_download_waiting_screen(question):
+                if download_wait_started is None:
+                    download_wait_started = time.monotonic()
+                waited = time.monotonic() - download_wait_started
+                step["download_wait_seconds"] = round(waited, 3)
+                if waited > limits.download_task_timeout:
+                    result["failure"] = "download_task_timeout"
+                    break
+                time.sleep(2)
+                continue
+            download_wait_started = None
+            if consecutive > limits.max_same_screen:
+                result["failure"] = "consecutive_repeated_state"
+                break
+            if state_visits[fingerprint] > limits.max_same_state_visits:
+                result["failure"] = "revisited_state_loop"
+                break
+            if is_terminal(question):
+                result["terminal_id"] = qid
+                expected_terminal_ids = set(scenario.get("expected_terminal_ids", []))
+                if expected_terminal_ids and qid not in expected_terminal_ids:
+                    result["failure"] = "unexpected_terminal"
+                    result["expected_terminal_ids"] = sorted(expected_terminal_ids)
+                else:
+                    result["status"] = "pass"
+                    result["failure"] = None
+                break
+
+            answer = build_answer(question, variables)
+            step["answer"] = answer
+            response = client.answer(
+                interview,
+                session,
+                secret,
+                answer,
+                question.get("event_list") or [],
+            )
+            if is_error(response):
+                result["failure"] = "error_after_answer"
+                step["response"] = response
+                break
+        else:
+            result["failure"] = "max_steps_exhausted"
+    except requests.Timeout as exc:
+        result["failure"] = "request_timeout"
+        result["exception"] = str(exc)
+    except requests.RequestException as exc:
+        result["failure"] = "http_error"
+        result["exception"] = str(exc)
+        if getattr(exc, "response", None) is not None:
+            result["response"] = exc.response.text[:2000]
+    except Exception as exc:  # strict ledger: unexpected harness errors also fail
+        result["failure"] = "driver_exception"
+        result["exception"] = f"{type(exc).__name__}: {exc}"
+    finally:
+        result["elapsed_seconds"] = round(time.monotonic() - started, 3)
+        if session:
+            client.delete(interview, session, secret)
+    return result
+
+
+def load_limits(model_path: Path) -> Limits:
+    model = yaml.safe_load(model_path.read_text())
+    policy = model["hang_policy"]
+    return Limits(
+        request_timeout=int(policy["request_timeout_seconds"]),
+        scenario_timeout=int(policy["scenario_timeout_seconds"]),
+        max_steps=int(policy["max_steps"]),
+        max_same_screen=int(policy["max_same_screen_consecutive"]),
+        max_same_state_visits=int(policy["max_same_state_visits"]),
+        download_task_timeout=int(policy["download_task_timeout_seconds"]),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server", default=os.environ.get("DA_SERVER_URL", ""))
+    parser.add_argument("--api-key", default=os.environ.get("DA_API_KEY", ""))
+    parser.add_argument("--scenarios", type=Path, default=HERE / "scenarios")
+    parser.add_argument("--model", type=Path, default=HERE / "coverage_model.yml")
+    parser.add_argument("--ledger", type=Path, default=HERE / "runtime_ledger.json")
+    args = parser.parse_args()
+    if not args.server or not args.api_key:
+        parser.error("--server and --api-key (or DA_SERVER_URL/DA_API_KEY) are required")
+
+    limits = load_limits(args.model)
+    client = Client(args.server, args.api_key, limits.request_timeout)
+    scenarios = [json.loads(path.read_text()) for path in sorted(args.scenarios.glob("*.json"))]
+    results = [run_scenario(client, scenario, limits) for scenario in scenarios]
+    ledger = {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "server": args.server,
+        "results": results,
+        "summary": {
+            "scenarios": len(results),
+            "passed": sum(result["status"] == "pass" for result in results),
+            "failed": sum(result["status"] != "pass" for result in results),
+            "unique_screen_ids": len({screen for result in results for screen in result["seen_screen_ids"]}),
+        },
+    }
+    args.ledger.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(ledger["summary"], sort_keys=True))
+    for result in results:
+        print(f"{result['status'].upper()} {result['name']}: {result.get('failure') or result.get('terminal_id')}")
+    return 1 if ledger["summary"]["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -954,6 +954,8 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                             "event": probe["event"],
                             "id": probe_id,
                             "type": probe_question.get("questionType"),
+                            "source_file": question_source_file(probe_question, interview),
+                            "source_fingerprint": source_document_fingerprint(probe_question),
                         }
                         result["event_probes"].append(probe_result)
                         if probe_id not in result["seen_screen_ids"]:

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -37,12 +37,20 @@ def question_id(question: dict[str, Any]) -> str:
 
 
 def question_variable(question: dict[str, Any]) -> str:
-    return str(
+    direct = str(
         question.get("question_variable_name")
         or question.get("continue_button_field")
         or question.get("continueButtonField")
         or ""
     )
+    if direct:
+        return direct
+    # For reusable questions whose source fields contain ``[i]``, the API
+    # exposes the concrete variable being sought in ``event_list`` even when
+    # it omits question_variable_name. That concrete name is authoritative for
+    # resolving the iterator before submitting the answer.
+    events = question.get("event_list") or []
+    return str(events[0]) if events else ""
 
 
 def question_fingerprint(question: dict[str, Any]) -> str:
@@ -137,7 +145,8 @@ def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[i
     """Count a serialized collection at a dotted path, with ``[*]`` fan-out."""
     values: list[Any] = [root]
     used_wildcard = False
-    for part in path.split("."):
+    parts = path.split(".")
+    for part_index, part in enumerate(parts):
         match = re.fullmatch(r"([^\[]+)(?:\[(\*|\d+)\])?", part)
         if not match:
             return None
@@ -145,6 +154,11 @@ def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[i
         next_values: list[Any] = []
         for container in values:
             if not isinstance(container, dict) or name not in container:
+                # A missing nested collection on an existing wildcard parent
+                # is Docassemble's serialized representation of an empty
+                # optional list. Preserve that parent as cardinality zero.
+                if used_wildcard and part_index == len(parts) - 1:
+                    next_values.append([])
                 continue
             value = container[name]
             if index is None:
@@ -173,7 +187,14 @@ def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[i
 
 
 def resolve_generic(variable: str, sought: str) -> str:
-    if not variable.startswith(("x.", "x[")) or not sought:
+    if not sought:
+        return variable
+    if "[i]" in variable:
+        generic_root = variable.split("[i]", 1)[0]
+        index_match = re.search(rf"^{re.escape(generic_root)}\[(\d+)\]", sought)
+        if index_match:
+            return variable.replace("[i]", f"[{index_match.group(1)}]", 1)
+    if not variable.startswith(("x.", "x[")):
         return variable
     object_name = re.split(r"[.[]", sought, maxsplit=1)[0]
     index_match = re.search(r"\[(\d+)\]", sought)
@@ -362,7 +383,7 @@ def build_answer(
     hidden_names: set[str] = set()
     visible_names: set[str] = set()
     for field in fields:
-        controller = field.get("show_if_var")
+        controller = resolve_generic(str(field.get("show_if_var") or ""), sought)
         # The API can expose a Python expression (for example,
         # ``not showifdef("users1_gender")``) in show_if_var. We can safely
         # evaluate only a controller that is another submitted field on this
@@ -626,6 +647,9 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                             "expected": probe["expected"],
                             "observed": observed_count,
                         }
+                        if observed_count is None and probe["expected"] == 0:
+                            observed_count = 0
+                            result["cardinality_evidence"][name]["observed"] = 0
                         if observed_count != probe["expected"]:
                             cardinality_mismatches[name] = result["cardinality_evidence"][name]
                     if cardinality_mismatches:

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -802,6 +802,12 @@ class Client:
             payload["event_list"] = canonical(event_list)
         if question_name:
             payload["question_name"] = question_name
+        # Save the submitted variables first, then fetch the resulting screen.
+        # Besides matching the API's explicit partial-update mode, this keeps
+        # the committed session available when next-screen assembly fails and
+        # lets GET /question report the underlying assembly exception instead
+        # of the opaque set-and-assemble wrapper error.
+        payload["question"] = 0
         with ExitStack() as stack:
             files = {
                 name: stack.enter_context(open((HERE.parents[1] / relative).resolve(), "rb"))
@@ -814,7 +820,7 @@ class Client:
                 timeout=self.timeout,
             )
         response.raise_for_status()
-        return response.json()
+        return self.question(interview, session, secret)
 
     def action(
         self,
@@ -949,7 +955,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         values=list(evidence_names)
                         + [
                             "combined_bundle_enabled_document_names",
-                            "al_user_bundle._downloadable_files",
+                            "combined_bundle_downloadable_files",
                         ],
                         counts=[
                             path
@@ -969,7 +975,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                     )
                     result["bundle_enabled_documents"] = sorted(enabled_documents)
                     result["bundle_download_evidence"] = serialized_download_evidence(
-                        terminal_variables.get("al_user_bundle._downloadable_files")
+                        terminal_variables.get("combined_bundle_downloadable_files")
                     )
                     expected_bundle = scenario.get("expected_bundle_documents", {})
                     expected_enabled = {
@@ -1208,6 +1214,11 @@ def main() -> int:
     parser.add_argument("--server", default=os.environ.get("DA_SERVER_URL", ""))
     parser.add_argument("--api-key", default=os.environ.get("DA_API_KEY", ""))
     parser.add_argument("--scenarios", type=Path, default=HERE / "scenarios")
+    parser.add_argument(
+        "--scenario-pattern",
+        default="",
+        help="run scenario names that fully match this regex (for focused CI diagnosis)",
+    )
     parser.add_argument("--model", type=Path, default=HERE / "coverage_model.yml")
     parser.add_argument("--ledger", type=Path, default=HERE / "runtime_ledger.json")
     args = parser.parse_args()
@@ -1220,6 +1231,19 @@ def main() -> int:
     if workers < 1:
         parser.error("hang_policy.runtime_workers must be at least 1")
     scenarios = [json.loads(path.read_text()) for path in sorted(args.scenarios.glob("*.json"))]
+    if args.scenario_pattern:
+        try:
+            scenario_pattern = re.compile(args.scenario_pattern)
+        except re.error as exc:
+            parser.error(f"invalid --scenario-pattern: {exc}")
+        scenarios = [
+            scenario for scenario in scenarios
+            if scenario_pattern.fullmatch(str(scenario.get("name", "")))
+        ]
+        if not scenarios:
+            parser.error(
+                f"no generated scenario matches {args.scenario_pattern!r}"
+            )
     indexed_results: dict[int, dict[str, Any]] = {}
 
     def run_indexed(index: int, scenario: dict[str, Any]) -> tuple[int, dict[str, Any]]:

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -71,13 +71,22 @@ def question_variable(question: dict[str, Any]) -> str:
         or question.get("continueButtonField")
         or ""
     )
+    events = question.get("event_list") or []
+    # Some reusable screens report a literal ``users[i]`` question variable
+    # while their event list contains the concrete iterator value. Prefer that
+    # concrete event so all fields on the screen resolve to the modeled person.
+    if direct and "[i]" in direct:
+        normalized_direct = normalized_variable(direct)
+        for event in events:
+            event_name = str(event)
+            if "[i]" not in event_name and normalized_variable(event_name) == normalized_direct:
+                return event_name
     if direct:
         return direct
     # For reusable questions whose source fields contain ``[i]``, the API
     # exposes the concrete variable being sought in ``event_list`` even when
     # it omits question_variable_name. That concrete name is authoritative for
     # resolving the iterator before submitting the answer.
-    events = question.get("event_list") or []
     return str(events[0]) if events else ""
 
 

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -208,15 +208,58 @@ def serialized_checkboxes(resolved: str, choices: list[Any], selected: Any) -> d
     }
 
 
-def answer_for_field(field: dict[str, Any], resolved: str, variables: dict[str, Any]) -> Any:
-    if resolved in variables:
-        value = variables[resolved]
-    elif field["variable"] in variables:
-        value = variables[field["variable"]]
+def scenario_value(
+    variables: dict[str, Any],
+    resolved: str,
+    raw: str,
+    sequence_positions: dict[str, int] | None = None,
+) -> tuple[bool, Any]:
+    """Return an exact or index-normalized modeled answer.
+
+    ``$sequence`` values let a scenario answer repeated list controls such as
+    ``there_is_another`` deterministically. Exhaustion is an error: silently
+    repeating the last value could conceal an unexpected traversal loop.
+    """
+    for key in dict.fromkeys((resolved, raw, normalized_variable(resolved), normalized_variable(raw))):
+        if key not in variables:
+            continue
+        value = variables[key]
+        if isinstance(value, dict) and set(value) == {"$sequence"}:
+            sequence = value["$sequence"]
+            if not isinstance(sequence, list) or not sequence:
+                raise ValueError(f"modeled answer sequence for {key} must be a non-empty list")
+            positions = sequence_positions if sequence_positions is not None else {}
+            position = positions.get(key, 0)
+            if position >= len(sequence):
+                raise ValueError(f"modeled answer sequence exhausted for {key}")
+            positions[key] = position + 1
+            return True, sequence[position]
+        return True, value
+    return False, None
+
+
+def answer_for_field(
+    field: dict[str, Any],
+    resolved: str,
+    variables: dict[str, Any],
+    sequence_positions: dict[str, int] | None = None,
+) -> Any:
+    found, value = scenario_value(
+        variables,
+        resolved,
+        field["variable"],
+        sequence_positions,
+    )
+    if found:
+        pass
     elif field["datatype"] == "file":
         value = ""
     elif field["datatype"] == "checkboxes":
         value = {}
+    elif normalized_variable(resolved).endswith((".there_are_any", ".there_is_another")):
+        # Empty is the safe representative for a list unless the scenario
+        # explicitly claims a one-or-many cardinality.
+        value = False
     elif field["choices"]:
         value = first_choice(field["choices"])
     else:
@@ -234,10 +277,15 @@ def show_if_matches(actual: Any, expected: Any) -> bool:
     return actual == expected
 
 
-def build_answer(question: dict[str, Any], scenario_variables: dict[str, Any]) -> dict[str, Any]:
+def build_answer(
+    question: dict[str, Any],
+    scenario_variables: dict[str, Any],
+    sequence_positions: dict[str, int] | None = None,
+) -> dict[str, Any]:
     sought = question_variable(question)
     answer: dict[str, Any] = {}
     fields = field_info(question)
+    field_values: dict[str, Any] = {}
     for field in fields:
         raw = field["variable"]
         resolved = resolve_generic(raw, sought)
@@ -247,7 +295,14 @@ def build_answer(question: dict[str, Any], scenario_variables: dict[str, Any]) -
                 resolved, scenario_variables.get(raw, True)
             )
         else:
-            answer[send_name] = answer_for_field(field, resolved, scenario_variables)
+            if send_name not in field_values:
+                field_values[send_name] = answer_for_field(
+                    field,
+                    resolved,
+                    scenario_variables,
+                    sequence_positions,
+                )
+            answer[send_name] = field_values[send_name]
 
     # Do not submit fields hidden by a simple same-screen show-if condition.
     # A screen can declare multiple conditional variants of the same variable;
@@ -338,6 +393,7 @@ class Client:
         secret: str,
         variables: dict[str, Any],
         event_list: list[str] | None = None,
+        question_name: str | None = None,
     ) -> dict[str, Any]:
         payload = self._params(interview, session, secret)
         uploads = {
@@ -349,6 +405,8 @@ class Client:
         payload["variables"] = canonical(ordinary_variables)
         if event_list:
             payload["event_list"] = canonical(event_list)
+        if question_name:
+            payload["question_name"] = question_name
         with ExitStack() as stack:
             files = {
                 name: stack.enter_context(open((HERE.parents[1] / relative).resolve(), "rb"))
@@ -416,6 +474,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
         previous_state = ""
         consecutive = 0
         download_wait_started: float | None = None
+        sequence_positions: dict[str, int] = {}
         for step_number in range(1, limits.max_steps + 1):
             if time.monotonic() - started > limits.scenario_timeout:
                 result["failure"] = "scenario_timeout"
@@ -435,6 +494,8 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 "sought": question_variable(question),
                 "fields": field_info(question),
                 "event_list": question.get("event_list") or [],
+                "question_name": question.get("questionName"),
+                "mandatory": bool(question.get("mandatory")),
             }
             if question.get("questionType") == "undefined_variable":
                 step["undefined_variable"] = question.get("variable")
@@ -518,7 +579,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         result["failure"] = None
                 break
 
-            answer = build_answer(question, variables)
+            answer = build_answer(question, variables, sequence_positions)
             step["answer"] = answer
             response = client.answer(
                 interview,
@@ -526,6 +587,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 secret,
                 answer,
                 question.get("event_list") or [],
+                question.get("questionName") if question.get("mandatory") else None,
             )
             if is_error(response):
                 result["failure"] = "error_after_answer"

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -121,6 +121,16 @@ def is_download_waiting_screen(question: dict[str, Any]) -> bool:
     return qid == "waiting screen" or "al_download_waiting_screen" in events
 
 
+def serialized_collection_count(value: Any) -> int | None:
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, dict):
+        elements = value.get("elements")
+        if isinstance(elements, (list, dict)):
+            return len(elements)
+    return None
+
+
 def resolve_generic(variable: str, sought: str) -> str:
     if not variable.startswith(("x.", "x[")) or not sought:
         return variable
@@ -495,13 +505,11 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
             question = client.question(interview, session, secret)
             qid = question_id(question)
             fingerprint = question_fingerprint(question)
-            state_visits[fingerprint] = state_visits.get(fingerprint, 0) + 1
-            consecutive = consecutive + 1 if fingerprint == previous_state else 1
-            previous_state = fingerprint
             step = {
                 "number": step_number,
                 "id": qid,
                 "type": question.get("questionType"),
+                "question_keys": sorted(question),
                 "fingerprint": fingerprint,
                 "variant_fingerprint": screen_variant_fingerprint(question),
                 "sought": question_variable(question),
@@ -533,12 +541,6 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 time.sleep(2)
                 continue
             download_wait_started = None
-            if consecutive > limits.max_same_screen:
-                result["failure"] = "consecutive_repeated_state"
-                break
-            if state_visits[fingerprint] > limits.max_same_state_visits:
-                result["failure"] = "revisited_state_loop"
-                break
             if is_terminal(question):
                 result["terminal_id"] = qid
                 expected_terminal_ids = set(scenario.get("expected_terminal_ids", []))
@@ -565,6 +567,24 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         for name in evidence_names
                         if name in terminal_variables
                     }
+                    result["cardinality_evidence"] = {}
+                    cardinality_mismatches = {}
+                    for name, probe in scenario.get("expected_cardinalities", {}).items():
+                        variable_name = probe["variable"]
+                        observed_count = serialized_collection_count(
+                            terminal_variables.get(variable_name)
+                        )
+                        result["cardinality_evidence"][name] = {
+                            "variable": variable_name,
+                            "expected": probe["expected"],
+                            "observed": observed_count,
+                        }
+                        if observed_count != probe["expected"]:
+                            cardinality_mismatches[name] = result["cardinality_evidence"][name]
+                    if cardinality_mismatches:
+                        result["failure"] = "cardinality_evidence_mismatch"
+                        result["cardinality_evidence_mismatches"] = cardinality_mismatches
+                        break
                     expected_evidence = scenario.get("expected_terminal_evidence", {})
                     evidence_mismatches = {
                         name: {
@@ -612,6 +632,29 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
 
             answer = build_answer(question, variables, sequence_positions)
             step["answer"] = answer
+            # A repeated list-control screen is legitimate when a declared
+            # sequence is advancing. Include the answer and sequence cursor in
+            # the state identity so finite modeled traversal is not mistaken
+            # for a hang; an unchanged state still fails quickly, and an
+            # unexpected extra repetition exhausts the declared sequence.
+            state_payload = {
+                "question": fingerprint,
+                "answer": answer,
+                "sequence_positions": sequence_positions,
+            }
+            state_fingerprint = hashlib.sha256(
+                canonical(state_payload).encode()
+            ).hexdigest()[:16]
+            step["state_fingerprint"] = state_fingerprint
+            state_visits[state_fingerprint] = state_visits.get(state_fingerprint, 0) + 1
+            consecutive = consecutive + 1 if state_fingerprint == previous_state else 1
+            previous_state = state_fingerprint
+            if consecutive > limits.max_same_screen:
+                result["failure"] = "consecutive_repeated_state"
+                break
+            if state_visits[state_fingerprint] > limits.max_same_state_visits:
+                result["failure"] = "revisited_state_loop"
+                break
             response = client.answer(
                 interview,
                 session,

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -309,18 +309,21 @@ def field_within_cardinalities(
 def resolve_generic(variable: str, sought: str) -> str:
     if not sought:
         return variable
-    if "[i]" in variable:
-        generic_root = variable.split("[i]", 1)[0]
+    if variable.startswith(("x.", "x[")):
+        object_name = re.split(r"[.[]", sought, maxsplit=1)[0]
+        index_match = re.search(r"\[(\d+)\]", sought)
+        if variable.startswith("x[i]") and index_match:
+            return f"{object_name}[{index_match.group(1)}]{variable[4:]}"
+        return object_name + variable[1:]
+
+    resolved = variable
+    for iterator in re.findall(r"\[([a-z])\]", variable):
+        marker = f"[{iterator}]"
+        generic_root = resolved.split(marker, 1)[0]
         index_match = re.search(rf"^{re.escape(generic_root)}\[(\d+)\]", sought)
         if index_match:
-            return variable.replace("[i]", f"[{index_match.group(1)}]", 1)
-    if not variable.startswith(("x.", "x[")):
-        return variable
-    object_name = re.split(r"[.[]", sought, maxsplit=1)[0]
-    index_match = re.search(r"\[(\d+)\]", sought)
-    if variable.startswith("x[i]") and index_match:
-        return f"{object_name}[{index_match.group(1)}]{variable[4:]}"
-    return object_name + variable[1:]
+            resolved = resolved.replace(marker, f"[{index_match.group(1)}]", 1)
+    return resolved
 
 
 def field_info(question: dict[str, Any]) -> list[dict[str, Any]]:
@@ -458,6 +461,31 @@ def serialized_object_choices(
     return result
 
 
+def serialized_object_choice(
+    resolved: str,
+    choices: list[Any],
+    selected: Any,
+    current_variables: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Serialize one object reference instead of assigning its instance name string."""
+    available = {
+        str(choice.get("value")): choice
+        for choice in choices
+        if isinstance(choice, dict) and choice.get("value") is not None
+    }
+    selected_name = str(selected)
+    if selected_name not in available:
+        raise ValueError(
+            f"object selection for {resolved} contains unknown choice: {selected_name}"
+        )
+    if current_variables is None:
+        raise ValueError(f"object selection for {resolved} requires current session variables")
+    source = serialized_path_value(current_variables, selected_name)
+    if not isinstance(source, dict) or not source.get("_class"):
+        raise ValueError(f"object choice {selected_name} is absent from current session variables")
+    return copy.deepcopy(source)
+
+
 def scenario_value(
     variables: dict[str, Any],
     resolved: str,
@@ -537,6 +565,13 @@ def answer_for_field(
             value,
             current_variables,
         )
+    if field["datatype"] in {"object", "object_radio"} and field["choices"]:
+        return serialized_object_choice(
+            resolved,
+            field["choices"],
+            value,
+            current_variables,
+        )
     return value
 
 
@@ -564,7 +599,7 @@ def build_answer(
         resolved = resolve_generic(raw, sought)
         if not field_within_cardinalities(resolved, expected_cardinalities):
             continue
-        if field["datatype"] == "object" and any(
+        if field["datatype"] in {"object", "object_radio"} and any(
             resolve_generic(other["variable"], sought).startswith(resolved + ".")
             for other in fields
             if other is not field
@@ -598,6 +633,9 @@ def build_answer(
     hidden_names: set[str] = set()
     visible_names: set[str] = set()
     for field in fields:
+        raw = field["variable"]
+        resolved = resolve_generic(raw, sought)
+        send_name = raw if raw.startswith(("x.", "x[")) else resolved
         controller = resolve_generic(str(field.get("show_if_var") or ""), sought)
         # The API can expose a Python expression (for example,
         # ``not showifdef("users1_gender")``) in show_if_var. We can safely
@@ -605,10 +643,8 @@ def build_answer(
         # screen. Unknown or expression-based controllers stay visible so the
         # server, not the driver, remains the authority on their condition.
         if not controller or controller not in answer:
+            visible_names.add(send_name)
             continue
-        raw = field["variable"]
-        resolved = resolve_generic(raw, sought)
-        send_name = raw if raw.startswith(("x.", "x[")) else resolved
         controller_value = answer.get(controller)
         expected = field.get("show_if_val")
         condition_matches = show_if_matches(controller_value, expected)
@@ -1098,7 +1134,8 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 break
 
             needs_current_variables = any(
-                field["datatype"] in {"object_checkboxes", "object_multiselect"}
+                field["datatype"]
+                in {"object", "object_radio", "object_checkboxes", "object_multiselect"}
                 and field_within_cardinalities(
                     resolve_generic(field["variable"], question_variable(question)),
                     scenario.get("expected_cardinalities"),
@@ -1115,7 +1152,7 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                             str(choice.get("value"))
                             for field in field_info(question)
                             if field["datatype"]
-                            in {"object_checkboxes", "object_multiselect"}
+                            in {"object", "object_radio", "object_checkboxes", "object_multiselect"}
                             for choice in field["choices"]
                             if isinstance(choice, dict)
                             and choice.get("value") is not None

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -329,6 +329,13 @@ def build_answer(
     } | {field["variable"] for field in fields}
     if sought and sought not in field_names:
         answer[sought] = scenario_variables.get(sought, True)
+    if question.get("questionType") == "multiple_choice" and not fields:
+        # A code-button screen has no ordinary field. Its event list identifies
+        # the variable whose definition diverted interview logic to this
+        # screen; the first button in our modeled warnings is the continue
+        # action that sets that variable true.
+        for event_name in question.get("event_list", []) or []:
+            answer[str(event_name)] = scenario_variables.get(str(event_name), True)
     if not answer:
         normalized_id = question_id(question).replace(" ", "_").replace("-", "_")
         answer[normalized_id] = scenario_variables.get(normalized_id, True)
@@ -537,16 +544,34 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                     evidence_names = (
                         "al_user_bundle",
                         "divorcejointpetition_downloads_ready",
+                        "include_r408",
+                        "include_care_or_custody_affidavit",
                         "include_financial_statement",
+                        "include_financial_statement_spouse_1",
+                        "include_financial_statement_spouse_2",
                         "include_separation_agreement",
                         "include_child_support_guidelines_worksheet",
                         "include_findings_and_determinations",
+                        "needs_late_marriage_certificate_motion",
                     )
                     result["terminal_evidence"] = {
                         name: terminal_variables[name]
                         for name in evidence_names
                         if name in terminal_variables
                     }
+                    expected_evidence = scenario.get("expected_terminal_evidence", {})
+                    evidence_mismatches = {
+                        name: {
+                            "expected": expected,
+                            "observed": result["terminal_evidence"].get(name, "<missing>"),
+                        }
+                        for name, expected in expected_evidence.items()
+                        if result["terminal_evidence"].get(name, "<missing>") != expected
+                    }
+                    if evidence_mismatches:
+                        result["failure"] = "terminal_evidence_mismatch"
+                        result["terminal_evidence_mismatches"] = evidence_mismatches
+                        break
                     result["event_probes"] = []
                     for probe in scenario.get("probe_events", []):
                         client.action(

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -169,26 +169,13 @@ def serialized_collection_count(value: Any) -> int | None:
     return None
 
 
-def serialized_collection_elements(value: Any) -> list[Any]:
-    if isinstance(value, list):
-        return value
-    if isinstance(value, dict):
-        elements = value.get("elements")
-        if isinstance(elements, list):
-            return elements
-        if isinstance(elements, dict):
-            return list(elements.values())
-    return []
-
-
-def serialized_bundle_evidence(value: Any) -> dict[str, dict[str, Any]]:
-    """Compact a serialized ALDocumentBundle into generated-file evidence."""
+def serialized_download_evidence(value: Any) -> dict[str, Any]:
+    """Compact the exact ``_downloadable_files`` produced by the background task."""
 
     def file_records(node: Any) -> list[dict[str, Any]]:
         records: list[dict[str, Any]] = []
         if isinstance(node, dict):
-            class_name = str(node.get("_class", ""))
-            if class_name.endswith("DAFile"):
+            if str(node.get("_class", "")).endswith("DAFile"):
                 records.append(
                     {
                         "filename": node.get("filename"),
@@ -206,40 +193,38 @@ def serialized_bundle_evidence(value: Any) -> dict[str, dict[str, Any]]:
                 records.extend(file_records(nested))
         return records
 
-    result: dict[str, dict[str, Any]] = {}
-    for document in serialized_collection_elements(value):
+    document_results = value[0] if isinstance(value, list) and value else []
+    documents = []
+    for document in document_results if isinstance(document_results, list) else []:
         if not isinstance(document, dict):
             continue
-        name = str(document.get("instanceName") or "<unnamed>")
-        cache = document.get("cache")
-        cached_enabled = cache.get("enabled") if isinstance(cache, dict) else None
-        if document.get("always_enabled") is True:
-            enabled = True
-        elif isinstance(cached_enabled, bool):
-            enabled = cached_enabled
-        elif isinstance(document.get("enabled"), bool):
-            enabled = document["enabled"]
-        else:
-            enabled = None
-        files = file_records(document.get("elements"))
-        # Final and preview collections can serialize the same physical file
-        # more than once; retain one deterministic record per visible shape.
-        unique_files = {
-            canonical(record): record
-            for record in files
-        }
-        result[name] = {
-            "enabled": enabled,
-            "generated": any(record.get("ok") is True for record in unique_files.values()),
-            "files": sorted(
-                unique_files.values(),
-                key=lambda record: (
-                    str(record.get("filename")),
-                    str(record.get("extension")),
+        files = {canonical(record): record for record in file_records(document)}
+        documents.append(
+            {
+                "title": document.get("title"),
+                "files": sorted(
+                    files.values(),
+                    key=lambda record: (
+                        str(record.get("filename")),
+                        str(record.get("extension")),
+                    ),
                 ),
+            }
+        )
+    bundle_files = {
+        canonical(record): record
+        for record in file_records(value[1:] if isinstance(value, list) else [])
+    }
+    return {
+        "documents": documents,
+        "bundle_files": sorted(
+            bundle_files.values(),
+            key=lambda record: (
+                str(record.get("filename")),
+                str(record.get("extension")),
             ),
-        }
-    return result
+        ),
+    }
 
 
 def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[int] | None:
@@ -289,6 +274,8 @@ def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[i
 
 def serialized_path_value(root: dict[str, Any], path: str) -> Any:
     """Return a value from Docassemble's nested serialized object format."""
+    if path in root:
+        return root[path]
     value: Any = root
     for part in path.split("."):
         match = re.fullmatch(r"([^\[]+)(?:\[(\d+)\])?", part)
@@ -307,6 +294,15 @@ def serialized_path_value(root: dict[str, Any], path: str) -> Any:
             else:
                 return None
     return value
+
+
+def concrete_cardinality_paths(variable: str, expected: Any) -> list[str]:
+    """Expand one wildcard collection path into the finite modeled paths."""
+    if "[*]" not in variable:
+        return [variable]
+    if not isinstance(expected, list):
+        raise ValueError(f"wildcard cardinality {variable} requires a list expectation")
+    return [variable.replace("[*]", f"[{index}]", 1) for index in range(len(expected))]
 
 
 def field_within_cardinalities(
@@ -616,6 +612,18 @@ def build_answer(
         resolved = resolve_generic(raw, sought)
         if not field_within_cardinalities(resolved, expected_cardinalities):
             continue
+        if field["datatype"] == "object" and any(
+            resolve_generic(other["variable"], sought).startswith(resolved + ".")
+            for other in fields
+            if other is not field
+        ):
+            # A Docassemble object-choice field with ``disable others`` shares
+            # a screen with fields for constructing a new object. Submitting
+            # both the choice's string instance name and nested properties
+            # replaces the object with a string before the nested assignments.
+            # Leave the optional existing-object choice unanswered and fill
+            # the typed nested object instead.
+            continue
         send_name = raw if raw.startswith(("x.", "x[")) else resolved
         if question.get("questionType") == "settrue":
             answer[send_name] = scenario_variables.get(
@@ -745,10 +753,29 @@ class Client:
         response.raise_for_status()
         return response.json()
 
-    def variables(self, interview: str, session: str, secret: str) -> dict[str, Any]:
-        response = self.http.get(
-            f"{self.server}/api/session",
-            params=self._params(interview, session, secret),
+    def snapshot(
+        self,
+        interview: str,
+        session: str,
+        secret: str,
+        *,
+        values: list[str] | None = None,
+        counts: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Fetch a compact read-only snapshot without serializing the whole session."""
+        payload = self._params(interview, session, secret)
+        payload.update(
+            {
+                "action": "combined certification snapshot",
+                "read_only": 1,
+                "arguments": canonical(
+                    {"values": values or [], "counts": counts or []}
+                ),
+            }
+        )
+        response = self.http.post(
+            f"{self.server}/api/session/action",
+            data=payload,
             timeout=self.timeout,
         )
         response.raise_for_status()
@@ -895,7 +922,6 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                     result["failure"] = "unexpected_terminal"
                     result["expected_terminal_ids"] = sorted(expected_terminal_ids)
                 else:
-                    terminal_variables = client.variables(interview, session, secret)
                     evidence_names = (
                         "divorcejointpetition_downloads_ready",
                         "include_r408",
@@ -908,31 +934,74 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                         "include_findings_and_determinations",
                         "needs_late_marriage_certificate_motion",
                     )
+                    cardinality_paths = {
+                        name: concrete_cardinality_paths(
+                            probe["variable"], probe["expected"]
+                        )
+                        for name, probe in scenario.get(
+                            "expected_cardinalities", {}
+                        ).items()
+                    }
+                    terminal_variables = client.snapshot(
+                        interview,
+                        session,
+                        secret,
+                        values=list(evidence_names)
+                        + [
+                            "combined_bundle_enabled_document_names",
+                            "al_user_bundle._downloadable_files",
+                        ],
+                        counts=[
+                            path
+                            for paths in cardinality_paths.values()
+                            for path in paths
+                        ],
+                    )
                     result["terminal_evidence"] = {
                         name: terminal_variables[name]
                         for name in evidence_names
                         if name in terminal_variables
                     }
-                    result["bundle_evidence"] = serialized_bundle_evidence(
-                        terminal_variables.get("al_user_bundle")
+                    enabled_documents = set(
+                        terminal_variables.get(
+                            "combined_bundle_enabled_document_names", []
+                        )
+                    )
+                    result["bundle_enabled_documents"] = sorted(enabled_documents)
+                    result["bundle_download_evidence"] = serialized_download_evidence(
+                        terminal_variables.get("al_user_bundle._downloadable_files")
                     )
                     expected_bundle = scenario.get("expected_bundle_documents", {})
-                    bundle_mismatches = {}
-                    for name, expected_generated in expected_bundle.items():
-                        observed_document = result["bundle_evidence"].get(name)
-                        observed_generated = bool(
-                            observed_document and observed_document.get("generated")
-                        )
-                        failed_files = [
-                            record
-                            for record in (observed_document or {}).get("files", [])
-                            if record.get("ok") is False
-                        ]
-                        if observed_generated != expected_generated or failed_files:
-                            bundle_mismatches[name] = {
-                                "expected_generated": expected_generated,
-                                "observed": observed_document,
-                            }
+                    expected_enabled = {
+                        name for name, expected in expected_bundle.items() if expected
+                    }
+                    bundle_mismatches = {
+                        name: {
+                            "expected_enabled": expected,
+                            "observed_enabled": name in enabled_documents,
+                        }
+                        for name, expected in expected_bundle.items()
+                        if (name in enabled_documents) != expected
+                    }
+                    for name in enabled_documents - set(expected_bundle):
+                        bundle_mismatches[name] = {
+                            "expected_enabled": False,
+                            "observed_enabled": True,
+                        }
+                    download_documents = result["bundle_download_evidence"]["documents"]
+                    failed_downloads = [
+                        document
+                        for document in download_documents
+                        if not document["files"]
+                        or any(file.get("ok") is False for file in document["files"])
+                    ]
+                    if len(download_documents) != len(expected_enabled):
+                        bundle_mismatches["<download-count>"] = {
+                            "expected": len(expected_enabled),
+                            "observed": len(download_documents),
+                        }
+                    if failed_downloads:
+                        bundle_mismatches["<failed-downloads>"] = failed_downloads
                     if bundle_mismatches:
                         result["failure"] = "bundle_document_mismatch"
                         result["bundle_document_mismatches"] = bundle_mismatches
@@ -941,15 +1010,13 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                     cardinality_mismatches = {}
                     for name, probe in scenario.get("expected_cardinalities", {}).items():
                         variable_name = probe["variable"]
-                        if variable_name in terminal_variables:
-                            observed_count = serialized_collection_count(
-                                terminal_variables[variable_name]
-                            )
+                        paths = cardinality_paths[name]
+                        if isinstance(probe["expected"], list):
+                            observed_count = [
+                                terminal_variables.get(path, 0) for path in paths
+                            ]
                         else:
-                            observed_count = serialized_path_cardinality(
-                                terminal_variables,
-                                variable_name,
-                            )
+                            observed_count = terminal_variables.get(paths[0], 0)
                         result["cardinality_evidence"][name] = {
                             "variable": variable_name,
                             "expected": probe["expected"],
@@ -1020,7 +1087,22 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                 for field in field_info(question)
             )
             current_variables = (
-                client.variables(interview, session, secret)
+                client.snapshot(
+                    interview,
+                    session,
+                    secret,
+                    values=sorted(
+                        {
+                            str(choice.get("value"))
+                            for field in field_info(question)
+                            if field["datatype"]
+                            in {"object_checkboxes", "object_multiselect"}
+                            for choice in field["choices"]
+                            if isinstance(choice, dict)
+                            and choice.get("value") is not None
+                        }
+                    ),
+                )
                 if needs_current_variables
                 else None
             )

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -242,9 +242,18 @@ def build_answer(question: dict[str, Any], scenario_variables: dict[str, Any]) -
         raw = field["variable"]
         resolved = resolve_generic(raw, sought)
         send_name = raw if raw.startswith(("x.", "x[")) else resolved
-        answer[send_name] = answer_for_field(field, resolved, scenario_variables)
+        if question.get("questionType") == "settrue":
+            answer[send_name] = scenario_variables.get(
+                resolved, scenario_variables.get(raw, True)
+            )
+        else:
+            answer[send_name] = answer_for_field(field, resolved, scenario_variables)
 
     # Do not submit fields hidden by a simple same-screen show-if condition.
+    # A screen can declare multiple conditional variants of the same variable;
+    # keep the variable if at least one of those variants is visible.
+    hidden_names: set[str] = set()
+    visible_names: set[str] = set()
     for field in fields:
         controller = field.get("show_if_var")
         if not controller:
@@ -255,8 +264,9 @@ def build_answer(question: dict[str, Any], scenario_variables: dict[str, Any]) -
         controller_value = answer.get(controller)
         expected = field.get("show_if_val")
         visible = show_if_matches(controller_value, expected)
-        if not visible:
-            answer.pop(send_name, None)
+        (visible_names if visible else hidden_names).add(send_name)
+    for send_name in hidden_names - visible_names:
+        answer.pop(send_name, None)
 
     field_names = {
         resolve_generic(field["variable"], sought)
@@ -312,6 +322,15 @@ class Client:
         response.raise_for_status()
         return response.json()
 
+    def variables(self, interview: str, session: str, secret: str) -> dict[str, Any]:
+        response = self.http.get(
+            f"{self.server}/api/session",
+            params=self._params(interview, session, secret),
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
     def answer(
         self,
         interview: str,
@@ -343,6 +362,29 @@ class Client:
             )
         response.raise_for_status()
         return response.json()
+
+    def action(
+        self,
+        interview: str,
+        session: str,
+        secret: str,
+        action: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> None:
+        payload = self._params(interview, session, secret)
+        payload.update(
+            {
+                "action": action,
+                "persistent": 1,
+                "arguments": canonical(arguments or {}),
+            }
+        )
+        response = self.http.post(
+            f"{self.server}/api/session/action",
+            data=payload,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
 
     def delete(self, interview: str, session: str, secret: str) -> None:
         try:
@@ -430,8 +472,50 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                     result["failure"] = "unexpected_terminal"
                     result["expected_terminal_ids"] = sorted(expected_terminal_ids)
                 else:
-                    result["status"] = "pass"
-                    result["failure"] = None
+                    terminal_variables = client.variables(interview, session, secret)
+                    evidence_names = (
+                        "al_user_bundle",
+                        "divorcejointpetition_downloads_ready",
+                        "include_financial_statement",
+                        "include_separation_agreement",
+                        "include_child_support_guidelines_worksheet",
+                        "include_findings_and_determinations",
+                    )
+                    result["terminal_evidence"] = {
+                        name: terminal_variables[name]
+                        for name in evidence_names
+                        if name in terminal_variables
+                    }
+                    result["event_probes"] = []
+                    for probe in scenario.get("probe_events", []):
+                        client.action(
+                            interview,
+                            session,
+                            secret,
+                            probe["event"],
+                            probe.get("arguments"),
+                        )
+                        probe_question = client.question(interview, session, secret)
+                        probe_id = question_id(probe_question)
+                        probe_result = {
+                            "event": probe["event"],
+                            "id": probe_id,
+                            "type": probe_question.get("questionType"),
+                        }
+                        result["event_probes"].append(probe_result)
+                        if probe_id not in result["seen_screen_ids"]:
+                            result["seen_screen_ids"].append(probe_id)
+                        if is_error(probe_question):
+                            result["failure"] = "event_probe_error"
+                            probe_result["text"] = display_text(probe_question)[:1000]
+                            break
+                        if probe_id != probe["expected_id"]:
+                            result["failure"] = "unexpected_event_probe_screen"
+                            probe_result["expected_id"] = probe["expected_id"]
+                            break
+                    else:
+                        result["status"] = "pass"
+                        result["failure"] = None
                 break
 
             answer = build_answer(question, variables)

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -132,6 +132,45 @@ def serialized_collection_count(value: Any) -> int | None:
     return None
 
 
+def serialized_path_cardinality(root: dict[str, Any], path: str) -> int | list[int] | None:
+    """Count a serialized collection at a dotted path, with ``[*]`` fan-out."""
+    values: list[Any] = [root]
+    used_wildcard = False
+    for part in path.split("."):
+        match = re.fullmatch(r"([^\[]+)(?:\[(\*|\d+)\])?", part)
+        if not match:
+            return None
+        name, index = match.groups()
+        next_values: list[Any] = []
+        for container in values:
+            if not isinstance(container, dict) or name not in container:
+                continue
+            value = container[name]
+            if index is None:
+                next_values.append(value)
+                continue
+            elements = value.get("elements") if isinstance(value, dict) else value
+            if index == "*":
+                used_wildcard = True
+                if isinstance(elements, list):
+                    next_values.extend(elements)
+                elif isinstance(elements, dict):
+                    next_values.extend(elements.values())
+            elif isinstance(elements, list) and int(index) < len(elements):
+                next_values.append(elements[int(index)])
+            elif isinstance(elements, dict) and index in elements:
+                next_values.append(elements[index])
+        values = next_values
+    counts = [
+        count
+        for value in values
+        if (count := serialized_collection_count(value)) is not None
+    ]
+    if used_wildcard:
+        return counts
+    return counts[0] if counts else None
+
+
 def resolve_generic(variable: str, sought: str) -> str:
     if not variable.startswith(("x.", "x[")) or not sought:
         return variable
@@ -572,9 +611,15 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
                     cardinality_mismatches = {}
                     for name, probe in scenario.get("expected_cardinalities", {}).items():
                         variable_name = probe["variable"]
-                        observed_count = serialized_collection_count(
-                            terminal_variables.get(variable_name)
-                        )
+                        if variable_name in terminal_variables:
+                            observed_count = serialized_collection_count(
+                                terminal_variables[variable_name]
+                            )
+                        else:
+                            observed_count = serialized_path_cardinality(
+                                terminal_variables,
+                                variable_name,
+                            )
                         result["cardinality_evidence"][name] = {
                             "variable": variable_name,
                             "expected": probe["expected"],

--- a/tests/certification/runtime_driver.py
+++ b/tests/certification/runtime_driver.py
@@ -887,9 +887,21 @@ def run_scenario(client: Client, scenario: dict[str, Any], limits: Limits) -> di
             if is_terminal(question):
                 result["terminal_id"] = qid
                 expected_terminal_ids = set(scenario.get("expected_terminal_ids", []))
+                missing_required_screens = sorted(
+                    set(scenario.get("required_screen_ids", []))
+                    - set(result["seen_screen_ids"])
+                )
+                forbidden_screens_seen = sorted(
+                    set(scenario.get("forbidden_screen_ids", []))
+                    & set(result["seen_screen_ids"])
+                )
                 if expected_terminal_ids and qid not in expected_terminal_ids:
                     result["failure"] = "unexpected_terminal"
                     result["expected_terminal_ids"] = sorted(expected_terminal_ids)
+                elif missing_required_screens or forbidden_screens_seen:
+                    result["failure"] = "screen_expectation_mismatch"
+                    result["missing_required_screen_ids"] = missing_required_screens
+                    result["forbidden_screen_ids_seen"] = forbidden_screens_seen
                 elif not scenario.get("terminal_assertions", True):
                     # Some modeled branches intentionally end on a child
                     # interview's explanatory dead end. Reaching the declared

--- a/tests/certification/scenarios/001_baseline_no_children_wait.json
+++ b/tests/certification/scenarios/001_baseline_no_children_wait.json
@@ -1,0 +1,43 @@
+{
+  "name": "baseline no children, no financial statements, agreement later",
+  "interview": "docassemble.MATC1ADivorceJointPetition:data/questions/main_joint_petition.yml",
+  "expected_terminal_ids": ["download divorce joint petition"],
+  "variables": {
+    "has_existing_1b_action": false,
+    "financial_statement_scope": "neither",
+    "legal_marriage": true,
+    "marriage_certificate_upload": "",
+    "massachusetts_residency": true,
+    "divorce_type_affirmations": {
+      "want_divorce": true,
+      "file_jointly": true,
+      "will_notarize": true
+    },
+    "children_of_marriage": false,
+    "separation_agreement_reached": true,
+    "separation_agreement_documented": false,
+    "separation_agreement_format": "wait",
+    "international_marriage": false,
+    "previous_action": false,
+    "who_lives_at_marital_home": "both",
+    "users[0].has_attorney": false,
+    "users[1].has_attorney": false,
+    "users[0].name.first": "Alex",
+    "users[0].name.last": "Example",
+    "users[1].name.first": "Bailey",
+    "users[1].name.last": "Example",
+    "users[0].address.address": "1 Main Street",
+    "users[0].address.city": "Boston",
+    "users[0].address.state": "MA",
+    "users[0].address.zip": "02108",
+    "users[1].address.address": "1 Main Street",
+    "users[1].address.city": "Boston",
+    "users[1].address.state": "MA",
+    "users[1].address.zip": "02108",
+    "marital_home.address": "1 Main Street",
+    "marital_home.city": "Boston",
+    "marital_home.state": "MA",
+    "marital_home.zip": "02108",
+    "ask_if_qualifies_for_fee_waiver": false
+  }
+}

--- a/tests/certification/scenarios/001_baseline_no_children_wait.json
+++ b/tests/certification/scenarios/001_baseline_no_children_wait.json
@@ -2,6 +2,16 @@
   "name": "baseline no children, no financial statements, agreement later",
   "interview": "docassemble.MATC1ADivorceJointPetition:data/questions/main_joint_petition.yml",
   "expected_terminal_ids": ["download divorce joint petition"],
+  "probe_events": [
+    {
+      "event": "review_divorcejointpetition",
+      "expected_id": "divorce joint petition review screen"
+    },
+    {
+      "event": "review_jointmotiontofilemarriagecertificatelate",
+      "expected_id": "jointmotiontofilemarriagecertificatelate review screen"
+    }
+  ],
   "variables": {
     "has_existing_1b_action": false,
     "financial_statement_scope": "neither",

--- a/tests/certification/screen_classification.yml
+++ b/tests/certification/screen_classification.yml
@@ -1,4 +1,174 @@
 # A screen may be listed here only by its exact source-file and YAML-block
 # coordinate, with source-backed proof that the combined parent cannot call it.
-# Empty reasons fail the coverage audit.
-proven_unreachable: {}
+# Empty reasons, stale coordinates, and classifications contradicted by runtime
+# observation fail the coverage audit.
+_reasons:
+  parent_shared_data: &parent_shared_data >-
+    The combined parent gathers or assigns this shared party, child, case, or court
+    value before invoking the child interview order, so Docassemble cannot seek this
+    child question block.
+  parent_packet_flow: &parent_packet_flow >-
+    The combined parent calls the child's core order but owns the packet review,
+    signing, preview, and download flow; it never calls this standalone child screen.
+  standalone_wrapper: &standalone_wrapper >-
+    This screen is called only by the child's standalone wrapper, which the combined
+    entrypoint does not include or invoke.
+  shadowed_question: &shadowed_question >-
+    A later active question block satisfies the same sought variable in the included
+    source, so Docassemble selects that block and cannot reach this older alternative.
+  commented_branch: &commented_branch >-
+    The child completion method or order comments out this branch or marks it unused,
+    and the combined parent has no independent call to it.
+  ask_number_list: &ask_number_list >-
+    This list is configured with ask_number=True and gathered through target_number,
+    so its one-at-a-time there_is_another question is not part of the active path.
+  selected_type_list: &selected_type_list >-
+    The active list path uses selected_types and move_checks_to_list, which fixes and
+    gathers its elements; the legacy one-at-a-time list question cannot be sought.
+  affidavit_body_reuse: &affidavit_body_reuse >-
+    The active affidavit-body income screen already gathers this same household
+    variable before the supplement order starts, so the duplicate supplement block
+    cannot be sought.
+  not_in_active_order: &not_in_active_order >-
+    The current child section order seeks the replacement list or section variables
+    and contains no reference to this legacy screen's continue field.
+  fixed_fee_defaults: &fixed_fee_defaults >-
+    set_indigency_defaults fixes the supported divorce filing fee and the affidavit
+    order seeks those fee variables directly, so the general fee-selection screen is
+    already satisfied.
+
+proven_unreachable:
+  # Affidavit of Indigency: the combined parent starts at ask_affidavit_questions
+  # after fixing case, parties, fees, and docket data.
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#2b5cb98539a4596c": *parent_packet_flow
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#3ecad6457d8dcd58": *fixed_fee_defaults
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#63c96bf68b827d30": *standalone_wrapper
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#743064ddc50a0468": *standalone_wrapper
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#79e947c3029ec2b0": *parent_shared_data
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#8b32f69165e536c3": *standalone_wrapper
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#9e1a905151943fb9": *parent_shared_data
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#c6186a178fa851fc": *parent_shared_data
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#d295fe3b1595cd34": >-
+    indigency_supplement_intro is defined by this block but is never sought by the
+    affidavit legal logic or supplement order used by the combined parent.
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#fd3c43d524265e5a": *parent_shared_data
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_body.yml#fdee8bc2c464a26a": *standalone_wrapper
+
+  # The supplement reuses values already collected by the affidavit body and
+  # bypasses its standalone review/preview controls.
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#0562107e2af9ee0c": *affidavit_body_reuse
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#26c024bb686e8720": *parent_packet_flow
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#2dadcb949fb98b21": *affidavit_body_reuse
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#4619f173eaf49ff8": *parent_packet_flow
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#48d6bed6d9d4ceea": *parent_packet_flow
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#63f87c34764de71e": *ask_number_list
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#6af1aac5680f6724": *parent_packet_flow
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#6b3ddb2a986a649e": *selected_type_list
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#880cb6b67cbd7851": *parent_packet_flow
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#8a0a36109f601a7f": *parent_shared_data
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#8c4675153e5e3bca": *selected_type_list
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#bcfdd8b49f9866b3": *parent_packet_flow
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#e20f7408ab0b0633": *parent_shared_data
+  "docassemble.ALAffidavitOfIndigency:data/questions/review_page.yml#c45b7a638cda4466": *standalone_wrapper
+
+  # Parent-owned shared intake and optional ODR-only review.
+  "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#361d87038f35c07b": *shadowed_question
+  "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#553a59ba864ffc79": >-
+    This event is only for the ODR import entry mode; the combined entrypoint has no
+    ODR import invocation or navigation link.
+  "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#984bf710c7539aed": *shadowed_question
+  "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#abd13045420afff7": *shadowed_question
+  "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#e6397238be2ef1b5": *shadowed_question
+
+  # The late-certificate motion contributes an attachment to the parent packet;
+  # its standalone intake and closing order are not called.
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#0da13fd8f45d5dcb": *parent_shared_data
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#1bad733c510b7692": *parent_shared_data
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#45f5f74aef50e882": *parent_packet_flow
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#49443cfa165857cb": *parent_packet_flow
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#5299f2fc0e83396f": *parent_packet_flow
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#575d57852c0b29e8": *standalone_wrapper
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#8e4b713758415763": *parent_packet_flow
+  "docassemble.MATC1ADivorceJointPetition:data/questions/joint-motion-to-file-marriage-certificate-late.yml#ae51796e43d670d1": *parent_packet_flow
+
+  # Child Support Guidelines worksheet shared setup and standalone closing.
+  "docassemble.MATCCSGWorksheet:data/questions/child_support_guidelines_worksheet_core.yml#0a006fdd52b9d629": *parent_shared_data
+  "docassemble.MATCCSGWorksheet:data/questions/child_support_guidelines_worksheet_core.yml#86fda9848bd8873c": *parent_shared_data
+  "docassemble.MATCCSGWorksheet:data/questions/child_support_guidelines_worksheet_core.yml#99a807fe38dbbdc6": *parent_shared_data
+  "docassemble.MATCCSGWorksheet:data/questions/child_support_guidelines_worksheet_core.yml#c9c120378700af5b": *parent_packet_flow
+  "docassemble.MATCCSGWorksheet:data/questions/child_support_guidelines_worksheet_core.yml#ddfabc90dbd0aebd": *parent_packet_flow
+
+  # Care/custody legacy alternatives, commented attorney-per-case branch, and
+  # standalone signing/download screens.
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#05ecfc224445ea7f": *commented_branch
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#099a26e647063033": *shadowed_question
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#0cc03cd5f72c5347": *commented_branch
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#142f394823f1ef45": *shadowed_question
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#184fc5a0b573b8e7": *parent_packet_flow
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#4463c5deeba823fd": *parent_shared_data
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#599fa389391f3788": *parent_shared_data
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#840a5c9f2c836121": *parent_packet_flow
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#88085fb1407f2cd2": *commented_branch
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#8a53d8fb84080a01": *shadowed_question
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#90fd2da769067186": *commented_branch
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#a8e707f227afb88f": *commented_branch
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#ae4ff753c5e9d368": *commented_branch
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#af007b2f6b7c3b01": *parent_shared_data
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#c26ccc71d5779408": *shadowed_question
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#d33caca480cccbb0": *parent_packet_flow
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#f1f17a56f7bcf904": *parent_shared_data
+  "docassemble.MATCChildCareOrCustodyDisclosureAffidavit:data/questions/affidavit_disclosing_care_or_custody.yml#fdc5eca78c571e91": *parent_packet_flow
+
+  # Financial child setup is preselected by financial_statement_scope. Legacy
+  # monolithic screens are not referenced by the current section orders.
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement.yml#e66edefc83337d8d": *parent_shared_data
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_long.yml#0de307d26492d8eb": *not_in_active_order
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_long.yml#368765e0433375d7": *not_in_active_order
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_long.yml#f00d2c2a79e08249": *not_in_active_order
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#0f0006571e889c5c": *not_in_active_order
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#4020aacb59218b84": *not_in_active_order
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#4b5f276d09a26cdf": *parent_shared_data
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#4e075e50ff1521d2": *parent_packet_flow
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#545c9208ba8d3a73": *parent_shared_data
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#824c0700b27e66fc": *not_in_active_order
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#e8ba96f8a7c7b645": *parent_shared_data
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#f5fd95b133a5b45c": *parent_shared_data
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_shared.yml#f9963ec4a5881e99": *parent_shared_data
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_short.yml#0742d74ad131b22b": *not_in_active_order
+  "docassemble.MATCFinancialStatement:data/questions/financial_statement_short.yml#dfb337ffb6f24598": *not_in_active_order
+
+  # The parent-owned motion order seeks each concrete field directly; the child
+  # interview's grouped intake screens therefore cannot be selected.
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#03ddc5cc083ca59d": *shadowed_question
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#05cee6ec29731513": *shadowed_question
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#0df0727b775fff15": *shadowed_question
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#1becf406ad2e8afb": *parent_shared_data
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#239d6aa1fb8d4d44": *parent_shared_data
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#638aa74f3e072f2a": *shadowed_question
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#6d5b3f28dc5a56db": *shadowed_question
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#75437a841b41d7fe": *shadowed_question
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#9f317ea9bb4ab07c": *shadowed_question
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#b2144ad4373912b9": *parent_shared_data
+  "docassemble.MATCMotionToAmend:data/questions/motion_to_amend.yml#c2ffb8e65371cc36": *shadowed_question
+
+  # Separation agreement shared intake and standalone closing.
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#0260fe781935845f": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#3664c572c0c899ea": *parent_packet_flow
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#3d589c5a75083b18": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#3d749219f47e43b9": *parent_packet_flow
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#3f6baef7308b8097": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#50a25fc1cbfd99ab": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#793184e3d6263830": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#a34dedb78eab9f43": *parent_packet_flow
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#a36e929349389e12": *standalone_wrapper
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#b28f9092bc99ea46": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#e0275884cf2e978b": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#f1b5820bf2327706": *parent_packet_flow
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#f33e860fad6e7f3a": *parent_shared_data
+
+  # Findings shared defaults and standalone closing.
+  "docassemble.matcfindingsanddeterminations:data/questions/cjd_305_findings_determinations_core.yml#5ff3463316f37876": *parent_shared_data
+  "docassemble.matcfindingsanddeterminations:data/questions/cjd_305_findings_determinations_core.yml#860740d378e0721a": *parent_packet_flow
+  "docassemble.matcfindingsanddeterminations:data/questions/cjd_305_findings_determinations_core.yml#8c299406d504b5b2": *parent_packet_flow
+  "docassemble.matcfindingsanddeterminations:data/questions/cjd_305_findings_determinations_core.yml#be89ca8a15d0ab30": *parent_shared_data
+  "docassemble.matcfindingsanddeterminations:data/questions/cjd_305_findings_determinations_core.yml#ff12363cf1c9c640": *parent_shared_data

--- a/tests/certification/screen_classification.yml
+++ b/tests/certification/screen_classification.yml
@@ -57,13 +57,27 @@ proven_unreachable:
   # The supplement reuses values already collected by the affidavit body and
   # bypasses its standalone review/preview controls.
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#0562107e2af9ee0c": *affidavit_body_reuse
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#260412ec4d7156d3": >-
+    The immediately preceding income-source-amount block gathers source, cadence,
+    and value for the same concrete list item. The active selected-types list seeks
+    source first, so that superset block fills cadence and value before this narrower
+    duplicate could be sought; runtime selected fingerprint d10c302aa92ec23b.
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#26c024bb686e8720": *parent_packet_flow
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#2dadcb949fb98b21": *affidavit_body_reuse
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#30bbad777b791552": >-
+    The combined include graph gives the later financial-statement ALExpenseList
+    questions active precedence for users[0].expenses: runtime selected
+    fs_expense_sources (9279c714a97ebe10), whose matching fs_expense_item
+    (686ecaa425146529) gathers each selected item's source, value, and cadence.
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#4619f173eaf49ff8": *parent_packet_flow
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#48d6bed6d9d4ceea": *parent_packet_flow
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#63f87c34764de71e": *ask_number_list
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#6af1aac5680f6724": *parent_packet_flow
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#6b3ddb2a986a649e": *selected_type_list
+  "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#7873d9beecc46fab": >-
+    The supplement order seeks users[0].expenses.gathered through the selected-types
+    list flow and never references the keyed users[0].expenses["other"] fields; the
+    list creates integer-indexed items, so this legacy keyed-item screen is not sought.
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#880cb6b67cbd7851": *parent_packet_flow
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#8a0a36109f601a7f": *parent_shared_data
   "docassemble.ALAffidavitOfIndigency:data/questions/affidavit_of_indigency_supplement_body.yml#8c4675153e5e3bca": *selected_type_list
@@ -73,6 +87,7 @@ proven_unreachable:
 
   # Parent-owned shared intake and optional ODR-only review.
   "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#361d87038f35c07b": *shadowed_question
+  "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#45f5f74aef50e882": *shadowed_question
   "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml#553a59ba864ffc79": >-
     This event is only for the ODR import entry mode; the combined entrypoint has no
     ODR import invocation or navigation link.
@@ -159,6 +174,7 @@ proven_unreachable:
   "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#3f6baef7308b8097": *parent_shared_data
   "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#50a25fc1cbfd99ab": *parent_shared_data
   "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#793184e3d6263830": *parent_shared_data
+  "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#99c8c7fc7f50dcd6": *shadowed_question
   "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#a34dedb78eab9f43": *parent_packet_flow
   "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#a36e929349389e12": *standalone_wrapper
   "docassemble.MATCSeparationAgreement:data/questions/separation_agreement_core.yml#b28f9092bc99ea46": *parent_shared_data

--- a/tests/certification/screen_classification.yml
+++ b/tests/certification/screen_classification.yml
@@ -1,0 +1,3 @@
+# A screen may be listed here only with source-backed proof that the combined
+# parent cannot call it. Empty reasons fail the coverage audit.
+proven_unreachable: {}

--- a/tests/certification/screen_classification.yml
+++ b/tests/certification/screen_classification.yml
@@ -1,3 +1,4 @@
-# A screen may be listed here only with source-backed proof that the combined
-# parent cannot call it. Empty reasons fail the coverage audit.
+# A screen may be listed here only by its exact source-file and YAML-block
+# coordinate, with source-backed proof that the combined parent cannot call it.
+# Empty reasons fail the coverage audit.
 proven_unreachable: {}

--- a/tests/certification/test_audit_coverage.py
+++ b/tests/certification/test_audit_coverage.py
@@ -59,6 +59,24 @@ class CoverageAuditTests(unittest.TestCase):
         )
         self.assertTrue(report["passed"])
 
+    def test_runtime_observation_contradicts_unreachable_classification(self):
+        catalog = {"screens": [{"id": "one"}]}
+        ledger = {
+            "results": [{
+                "name": "path",
+                "status": "pass",
+                "seen_screen_ids": ["one"],
+            }]
+        }
+        report = audit(
+            catalog,
+            ledger,
+            {"proven_unreachable": {"id:one": "Incorrectly classified."}},
+        )
+
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["observed_exclusions"], ["id:one"])
+
     def test_failed_runtime_path_fails_even_with_full_screen_coverage(self):
         catalog = {"screens": [{"id": "one"}]}
         ledger = {

--- a/tests/certification/test_audit_coverage.py
+++ b/tests/certification/test_audit_coverage.py
@@ -20,7 +20,7 @@ class CoverageAuditTests(unittest.TestCase):
         }
         report = audit(catalog, ledger, {"proven_unreachable": {}})
         self.assertTrue(report["passed"])
-        self.assertEqual(report["unobserved_framework_catalog_screen_ids"], 1)
+        self.assertEqual(report["unobserved_framework_catalog_screens"], 1)
 
     def test_missing_cardinality_class_fails(self):
         catalog = {"screens": [{"id": "one"}]}
@@ -55,7 +55,7 @@ class CoverageAuditTests(unittest.TestCase):
         report = audit(
             catalog,
             ledger,
-            {"proven_unreachable": {"standalone only": "Not called by the combined parent order."}},
+            {"proven_unreachable": {"id:standalone only": "Not called by the combined parent order."}},
         )
         self.assertTrue(report["passed"])
 
@@ -84,11 +84,19 @@ class CoverageAuditTests(unittest.TestCase):
         self.assertFalse(report["passed"])
         self.assertEqual(report["missing_modeled_paths"], ["not run"])
 
-    def test_duplicate_id_requires_each_distinct_static_variant(self):
+    def test_duplicate_id_requires_each_exact_source_block(self):
         catalog = {
             "screens": [
-                {"id": "shared", "variables": ["first"]},
-                {"id": "shared", "variables": ["second"]},
+                {
+                    "id": "shared",
+                    "source_file": "docassemble.example:data/questions/one.yml",
+                    "source_fingerprint": "first",
+                },
+                {
+                    "id": "shared",
+                    "source_file": "docassemble.example:data/questions/two.yml",
+                    "source_fingerprint": "second",
+                },
             ]
         }
         ledger = {
@@ -96,14 +104,23 @@ class CoverageAuditTests(unittest.TestCase):
                 "name": "path",
                 "status": "pass",
                 "seen_screen_ids": ["shared"],
-                "steps": [{"id": "shared", "variant_fingerprint": "only-one"}],
+                "steps": [{
+                    "id": "shared",
+                    "source_file": "docassemble.example:data/questions/one.yml",
+                    "source_fingerprint": "first",
+                }],
             }]
         }
         report = audit(catalog, ledger, {"proven_unreachable": {}})
         self.assertFalse(report["passed"])
         self.assertEqual(
-            report["missing_screen_variants"]["shared"],
-            {"expected": 2, "observed": 1},
+            report["missing_local_screens"],
+            [{
+                "coordinate": "docassemble.example:data/questions/two.yml#second",
+                "id": "shared",
+                "source_file": "docassemble.example:data/questions/two.yml",
+                "document_index": None,
+            }],
         )
 
 

--- a/tests/certification/test_audit_coverage.py
+++ b/tests/certification/test_audit_coverage.py
@@ -4,6 +4,44 @@ from audit_coverage import audit
 
 
 class CoverageAuditTests(unittest.TestCase):
+    def test_unobserved_framework_utility_is_not_a_combined_feature_obligation(self):
+        catalog = {
+            "screens": [
+                {"id": "feature", "coverage_scope": "combined_feature"},
+                {"id": "saved sessions", "coverage_scope": "framework_support"},
+            ]
+        }
+        ledger = {
+            "results": [{
+                "name": "path",
+                "status": "pass",
+                "seen_screen_ids": ["feature"],
+            }]
+        }
+        report = audit(catalog, ledger, {"proven_unreachable": {}})
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["unobserved_framework_catalog_screen_ids"], 1)
+
+    def test_missing_cardinality_class_fails(self):
+        catalog = {"screens": [{"id": "one"}]}
+        ledger = {
+            "results": [{
+                "name": "path",
+                "status": "pass",
+                "seen_screen_ids": ["one"],
+                "cardinality_evidence": {
+                    "items": {"expected": 1, "observed": 1},
+                },
+            }]
+        }
+        model = {
+            "modeled_paths": [{"name": "path"}],
+            "cardinality_classes": {"items": [0, 1, 2]},
+        }
+        report = audit(catalog, ledger, {"proven_unreachable": {}}, model)
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["missing_cardinality_classes"], {"items": [0, 2]})
+
     def test_missing_declared_screen_fails(self):
         catalog = {"screens": [{"id": "one"}, {"id": "two"}]}
         ledger = {"results": [{"name": "path", "status": "pass", "seen_screen_ids": ["one"]}]}

--- a/tests/certification/test_audit_coverage.py
+++ b/tests/certification/test_audit_coverage.py
@@ -123,6 +123,29 @@ class CoverageAuditTests(unittest.TestCase):
             }],
         )
 
+    def test_unique_fingerprint_resolves_abbreviated_runtime_source_file(self):
+        catalog = {
+            "screens": [{
+                "id": "petition",
+                "source_file": "docassemble.example:data/questions/petition.yml",
+                "source_fingerprint": "exact-block",
+            }]
+        }
+        ledger = {
+            "results": [{
+                "name": "path",
+                "status": "pass",
+                "steps": [{
+                    "id": "petition",
+                    "source_file": "petition.yml",
+                    "source_fingerprint": "exact-block",
+                }],
+            }]
+        }
+        report = audit(catalog, ledger, {"proven_unreachable": {}})
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["observed_local_screens"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/certification/test_audit_coverage.py
+++ b/tests/certification/test_audit_coverage.py
@@ -1,0 +1,73 @@
+import unittest
+
+from audit_coverage import audit
+
+
+class CoverageAuditTests(unittest.TestCase):
+    def test_missing_declared_screen_fails(self):
+        catalog = {"screens": [{"id": "one"}, {"id": "two"}]}
+        ledger = {"results": [{"name": "path", "status": "pass", "seen_screen_ids": ["one"]}]}
+        report = audit(catalog, ledger, {"proven_unreachable": {}})
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["missing_local_screen_ids"], ["two"])
+
+    def test_reasoned_unreachable_classification_satisfies_denominator(self):
+        catalog = {"screens": [{"id": "one"}, {"id": "standalone only"}]}
+        ledger = {"results": [{"name": "path", "status": "pass", "seen_screen_ids": ["one"]}]}
+        report = audit(
+            catalog,
+            ledger,
+            {"proven_unreachable": {"standalone only": "Not called by the combined parent order."}},
+        )
+        self.assertTrue(report["passed"])
+
+    def test_failed_runtime_path_fails_even_with_full_screen_coverage(self):
+        catalog = {"screens": [{"id": "one"}]}
+        ledger = {
+            "results": [
+                {
+                    "name": "path",
+                    "status": "fail",
+                    "failure": "request_timeout",
+                    "seen_screen_ids": ["one"],
+                    "steps": [{"id": "one"}],
+                }
+            ]
+        }
+        report = audit(catalog, ledger, {"proven_unreachable": {}})
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["failed_paths"][0]["failure"], "request_timeout")
+
+    def test_missing_modeled_path_fails(self):
+        catalog = {"screens": [{"id": "one"}]}
+        ledger = {"results": [{"name": "ran", "status": "pass", "seen_screen_ids": ["one"]}]}
+        model = {"modeled_paths": [{"name": "ran"}, {"name": "not run"}]}
+        report = audit(catalog, ledger, {"proven_unreachable": {}}, model)
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["missing_modeled_paths"], ["not run"])
+
+    def test_duplicate_id_requires_each_distinct_static_variant(self):
+        catalog = {
+            "screens": [
+                {"id": "shared", "variables": ["first"]},
+                {"id": "shared", "variables": ["second"]},
+            ]
+        }
+        ledger = {
+            "results": [{
+                "name": "path",
+                "status": "pass",
+                "seen_screen_ids": ["shared"],
+                "steps": [{"id": "shared", "variant_fingerprint": "only-one"}],
+            }]
+        }
+        report = audit(catalog, ledger, {"proven_unreachable": {}})
+        self.assertFalse(report["passed"])
+        self.assertEqual(
+            report["missing_screen_variants"]["shared"],
+            {"expected": 2, "observed": 1},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/certification/test_build_catalog.py
+++ b/tests/certification/test_build_catalog.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import json
+import unittest
+
+from build_catalog import build_catalog
+
+
+HERE = Path(__file__).resolve().parent
+WORKSPACE = HERE.parents[2]
+
+
+class CatalogTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.baseline = json.loads((HERE / "baseline.json").read_text())
+        cls.catalog = build_catalog(WORKSPACE, cls.baseline)
+
+    def test_catalog_resolves_every_local_combined_include(self):
+        unresolved_local = [
+            include
+            for include in self.catalog["unresolved_external_includes"]
+            if include.split(":", 1)[0] in self.baseline["packages"]
+        ]
+        self.assertEqual(unresolved_local, [])
+
+    def test_every_unresolved_include_is_declared_external(self):
+        unresolved_packages = {
+            include.split(":", 1)[0]
+            for include in self.catalog["unresolved_external_includes"]
+        }
+        self.assertTrue(
+            unresolved_packages.issubset(set(self.baseline["external_packages"])),
+            f"undeclared external packages: {unresolved_packages - set(self.baseline['external_packages'])}",
+        )
+
+    def test_catalog_contains_known_combined_screens_and_orders(self):
+        screen_ids = {screen["id"] for screen in self.catalog["screens"]}
+        for screen_id in (
+            "existing 1B action screener",
+            "choose forms to include",
+            "Agreement on major issues",
+            "r408 demographics",
+            "child support worksheet result",
+            "download divorce joint petition",
+        ):
+            self.assertIn(screen_id, screen_ids)
+
+    def test_catalog_finds_known_top_level_branch_conditions(self):
+        expressions = {branch["expression"] for branch in self.catalog["branches"]}
+        self.assertIn("has_existing_1b_action", expressions)
+        self.assertIn("ask_if_qualifies_for_fee_waiver", expressions)
+        self.assertIn('separation_agreement_format == "interview"', expressions)
+
+    def test_catalog_captures_non_fields_question_variables(self):
+        sign_variants = [
+            screen for screen in self.catalog["screens"] if screen["id"] == "sign party A"
+        ]
+        self.assertEqual(len(sign_variants), 2)
+        self.assertEqual(
+            {tuple(screen["variables"]) for screen in sign_variants},
+            {("users[0].signature",)},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/certification/test_build_catalog.py
+++ b/tests/certification/test_build_catalog.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import json
 import unittest
 
-from build_catalog import build_catalog
+from build_catalog import build_catalog, source_document_fingerprint
 
 
 HERE = Path(__file__).resolve().parent
@@ -10,6 +10,14 @@ WORKSPACE = HERE.parents[2]
 
 
 class CatalogTests(unittest.TestCase):
+    def test_source_document_fingerprint_ignores_internal_metadata(self):
+        self.assertEqual(
+            source_document_fingerprint({"id": "one", "question": "Hello"}),
+            source_document_fingerprint(
+                {"id": "one", "question": "Hello", "_document_index": 7}
+            ),
+        )
+
     @classmethod
     def setUpClass(cls):
         cls.baseline = json.loads((HERE / "baseline.json").read_text())
@@ -74,6 +82,18 @@ class CatalogTests(unittest.TestCase):
             {tuple(screen["variables"]) for screen in sign_variants},
             {("users[0].signature",)},
         )
+
+    def test_catalog_records_exact_runtime_source_coordinates(self):
+        target = next(
+            screen
+            for screen in self.catalog["screens"]
+            if screen["id"] == "download divorce joint petition"
+        )
+        self.assertEqual(
+            target["source_file"],
+            "docassemble.MATC1ADivorceJointPetition:data/questions/divorce_joint_petition.yml",
+        )
+        self.assertRegex(target["source_fingerprint"], r"^[0-9a-f]{16}$")
 
 
 if __name__ == "__main__":

--- a/tests/certification/test_build_catalog.py
+++ b/tests/certification/test_build_catalog.py
@@ -45,6 +45,20 @@ class CatalogTests(unittest.TestCase):
         ):
             self.assertIn(screen_id, screen_ids)
 
+    def test_catalog_separates_feature_screens_from_framework_support(self):
+        scopes = {
+            (screen["package"], screen["coverage_scope"])
+            for screen in self.catalog["screens"]
+        }
+        self.assertIn(
+            ("docassemble.MATCFinancialStatement", "combined_feature"),
+            scopes,
+        )
+        self.assertIn(
+            ("docassemble.AssemblyLine", "framework_support"),
+            scopes,
+        )
+
     def test_catalog_finds_known_top_level_branch_conditions(self):
         expressions = {branch["expression"] for branch in self.catalog["branches"]}
         self.assertIn("has_existing_1b_action", expressions)

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -57,6 +57,7 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             "main_joint_petition.yml", "combined bundle enabled document names"
         )
         self.assertIn("al_user_bundle.enabled_documents(refresh=True)", bundle_names)
+        self.assertIn("del conditional_document.cache.enabled", bundle_names)
         download_evidence = identified_code(
             "main_joint_petition.yml", "combined bundle download evidence"
         )

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -76,6 +76,11 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             order.index("combined_bundle_enabled_document_names"),
             order.index("generate_downloads_with_docx_task"),
         )
+        self.assertIn('defined("al_user_bundle._downloadable_files")', order)
+        self.assertLess(
+            order.index("generate_downloads_with_docx_task.ready()"),
+            order.index('defined("al_user_bundle._downloadable_files")'),
+        )
         self.assertLess(
             order.index("combined_bundle_download_evidence"),
             order.index("divorcejointpetition_download", order.index("combined_bundle_download_evidence")),

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -52,6 +52,19 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             self.assertIn(f"generic object: users[i].{collection}", shared_source)
             self.assertIn(f"users[i].{collection}[j]", shared_source)
 
+    def test_long_expense_questions_are_scoped_to_the_long_form_list(self):
+        long_source = (
+            FINANCIAL_ROOT / "data" / "questions" / "financial_statement_long.yml"
+        ).read_text()
+
+        self.assertNotIn("generic object: ALExpenseList", long_source)
+        self.assertEqual(
+            long_source.count("generic object: users[i].long_expense_list"),
+            6,
+        )
+        self.assertIn("users[i].long_expense_list[j].source", long_source)
+        self.assertIn("users[i].long_expense_list[j].value", long_source)
+
     def test_certification_snapshot_is_compact_and_bundle_evidence_precedes_generation(self):
         all_documents = documents("main_joint_petition.yml")
         snapshots = [

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -24,6 +24,26 @@ def identified_code(filename: str, block_id: str) -> str:
 
 
 class CombinedSourceRegressionTests(unittest.TestCase):
+    def test_combined_parent_clears_standalone_document_enablement(self):
+        order = identified_code("main_joint_petition.yml", "joint petition interview order")
+        self.assertIn("combined_bundle_documents_normalized", order)
+        normalization_blocks = [
+            str(document.get("code", ""))
+            for document in documents("main_joint_petition.yml")
+            if "combined_bundle_documents_normalized = True" in str(document.get("code", ""))
+        ]
+        self.assertEqual(len(normalization_blocks), 1)
+        normalization = normalization_blocks[0]
+        for document_name in (
+            "motion_to_amend_attachment",
+            "users[0].financial_statement_short_attachment",
+            "users[1].financial_statement_long_attachment",
+            "a_divorce_agreement_attachment",
+            "affidavit_of_care_or_custody_attachment",
+        ):
+            self.assertIn(document_name, normalization)
+        self.assertIn("conditional_document.always_enabled = False", normalization)
+
     def test_uploaded_or_delayed_agreement_does_not_seek_built_agreement_state(self):
         order = identified_code("main_joint_petition.yml", "joint petition interview order")
         agreement_branch = order.split("if include_separation_agreement:", 1)[1].split(

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -36,6 +36,7 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         normalization = normalization_blocks[0]
         for document_name in (
             "motion_to_amend_attachment",
+            "r408_attachment",
             "users[0].financial_statement_short_attachment",
             "users[1].financial_statement_long_attachment",
             "a_divorce_agreement_attachment",

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -86,6 +86,16 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         question = child_questions[0]
         self.assertNotIn("list collect", question)
         self.assertIn("children[i].birthdate", str(question.get("fields", [])))
+        self.assertEqual(
+            set(question.get("sets", [])),
+            {
+                "children[i].name.first",
+                "children[i].name.last",
+                "children[i].name.middle",
+                "children[i].name.suffix",
+                "children[i].birthdate",
+            },
+        )
 
     def test_combined_motion_order_preserves_user_object_identity(self):
         joint_order = identified_code("main_joint_petition.yml", "joint petition interview order")

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -76,6 +76,17 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         ):
             self.assertIn(variable, order)
 
+    def test_combined_parent_owns_fixed_count_child_details(self):
+        child_questions = [
+            document
+            for document in documents("main_joint_petition.yml")
+            if document.get("id") == "combined child details"
+        ]
+        self.assertEqual(len(child_questions), 1)
+        question = child_questions[0]
+        self.assertNotIn("list collect", question)
+        self.assertIn("children[i].birthdate", str(question.get("fields", [])))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -29,16 +29,34 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         agreement_branch = order.split("if include_separation_agreement:", 1)[1].split(
             "# Findings and Determinations", 1
         )[0]
-        self.assertIn("provisions_that_merge.all_false()", agreement_branch)
-        self.assertIn("set_petition_merger_survival_from_agreement = True", agreement_branch)
+        self.assertNotIn("request_merge_agreement =", order)
+        self.assertNotIn("request_survive_agreement =", order)
+        self.assertIn("set_petition_merger_survival_values", agreement_branch)
 
-        competing_definitions = [
+        value_definitions = [
             document
             for document in documents("main_joint_petition.yml")
-            if "request_merge_agreement" in str(document.get("code", ""))
-            and document.get("id") != "joint petition interview order"
+            if "petition_request_merge_agreement" in str(document.get("code", ""))
         ]
-        self.assertEqual(competing_definitions, [])
+        self.assertEqual(len(value_definitions), 1)
+        value_definition = str(value_definitions[0]["code"])
+        self.assertIn("provisions_that_merge.all_false()", value_definition)
+        self.assertIn(
+            "petition_request_merge_agreement = request_merge_agreement",
+            value_definition,
+        )
+        self.assertIn(
+            "petition_request_survive_agreement = request_survive_agreement",
+            value_definition,
+        )
+
+        petition = "\n".join(
+            str(document)
+            for document in documents("divorce_joint_petition.yml")
+            if "request_merge_agreement" in str(document)
+        )
+        self.assertIn("${ petition_request_merge_agreement }", petition)
+        self.assertIn("${ petition_request_survive_agreement }", petition)
 
     def test_r408_order_seeks_field_variables_not_question_ids(self):
         order = identified_code("r408_report_of_absolute_divorce.yml", "interview order r408")

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -87,6 +87,19 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         self.assertNotIn("list collect", question)
         self.assertIn("children[i].birthdate", str(question.get("fields", [])))
 
+    def test_combined_motion_order_preserves_user_object_identity(self):
+        joint_order = identified_code("main_joint_petition.yml", "joint petition interview order")
+        combined_order = identified_code(
+            "main_joint_petition.yml", "combined interview order motion to amend"
+        )
+        self.assertIn("combined_interview_order_motion_to_amend", joint_order)
+        self.assertNotIn("\n  interview_order_motion_to_amend\n", joint_order)
+        self.assertNotIn("users.elements[0]", combined_order)
+        self.assertIn(
+            "users[0].name.first, users[1].name.first = users[1].name.first, users[0].name.first",
+            combined_order,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -50,20 +50,22 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             order.index("generate_downloads_with_docx_task"),
         )
         self.assertLess(
-            order.index("combined_bundle_downloadable_files"),
-            order.index("divorcejointpetition_download", order.index("combined_bundle_downloadable_files")),
+            order.index("combined_bundle_download_evidence"),
+            order.index("divorcejointpetition_download", order.index("combined_bundle_download_evidence")),
         )
         bundle_names = identified_code(
             "main_joint_petition.yml", "combined bundle enabled document names"
         )
         self.assertIn("al_user_bundle.enabled_documents(refresh=True)", bundle_names)
-        downloadable_files = identified_code(
-            "main_joint_petition.yml", "combined bundle downloadable files"
+        download_evidence = identified_code(
+            "main_joint_petition.yml", "combined bundle download evidence"
         )
         self.assertIn(
-            "combined_bundle_downloadable_files = al_user_bundle._downloadable_files",
-            downloadable_files,
+            "certification_document_results, certification_zip, certification_pdf = al_user_bundle._downloadable_files",
+            download_evidence,
         )
+        self.assertIn("combined_bundle_download_evidence", download_evidence)
+        self.assertNotIn("combined_bundle_downloadable_files", order)
 
     def test_combined_parent_clears_standalone_document_enablement(self):
         order = identified_code("main_joint_petition.yml", "joint petition interview order")

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -7,6 +7,7 @@ import yaml
 HERE = Path(__file__).resolve().parent
 QUESTION_ROOT = HERE.parents[1] / "docassemble" / "MATC1ADivorceJointPetition" / "data" / "questions"
 FINANCIAL_ROOT = HERE.parents[2] / "docassemble-MATCFinancialStatement" / "docassemble" / "MATCFinancialStatement"
+CERTIFICATION_WORKFLOW = HERE.parents[1] / ".github" / "workflows" / "certify-combined-interview.yml"
 
 
 def documents(filename: str) -> list[dict]:
@@ -25,6 +26,11 @@ def identified_code(filename: str, block_id: str) -> str:
 
 
 class CombinedSourceRegressionTests(unittest.TestCase):
+    def test_disposable_runtime_serializes_general_celery_tasks(self):
+        workflow_source = CERTIFICATION_WORKFLOW.read_text()
+
+        self.assertIn("--env DACELERYWORKERS=2", workflow_source)
+
     def test_financial_lists_do_not_store_owning_user_backreferences(self):
         question_source = "\n".join(
             path.read_text()

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -46,6 +46,10 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         self.assertEqual(len(order_documents), 1)
         order = str(order_documents[0]["code"])
         self.assertLess(
+            order.index("combined_bundle_final_packet_normalized"),
+            order.index("combined_bundle_enabled_document_names"),
+        )
+        self.assertLess(
             order.index("combined_bundle_enabled_document_names"),
             order.index("generate_downloads_with_docx_task"),
         )
@@ -57,7 +61,14 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             "main_joint_petition.yml", "combined bundle enabled document names"
         )
         self.assertIn("al_user_bundle.enabled_documents(refresh=True)", bundle_names)
-        self.assertIn("del conditional_document.cache.enabled", bundle_names)
+        self.assertNotIn("del conditional_document.cache.enabled", bundle_names)
+        final_normalization = identified_code(
+            "main_joint_petition.yml", "combined bundle final packet normalization"
+        )
+        self.assertIn("del conditional_document.cache.enabled", final_normalization)
+        self.assertIn(
+            "combined_bundle_final_packet_normalized = True", final_normalization
+        )
         download_evidence = identified_code(
             "main_joint_petition.yml", "combined bundle download evidence"
         )

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -6,6 +6,7 @@ import yaml
 
 HERE = Path(__file__).resolve().parent
 QUESTION_ROOT = HERE.parents[1] / "docassemble" / "MATC1ADivorceJointPetition" / "data" / "questions"
+FINANCIAL_ROOT = HERE.parents[2] / "docassemble-MATCFinancialStatement" / "docassemble" / "MATCFinancialStatement"
 
 
 def documents(filename: str) -> list[dict]:
@@ -24,6 +25,17 @@ def identified_code(filename: str, block_id: str) -> str:
 
 
 class CombinedSourceRegressionTests(unittest.TestCase):
+    def test_financial_lists_do_not_store_owning_user_backreferences(self):
+        question_source = "\n".join(
+            path.read_text()
+            for path in (FINANCIAL_ROOT / "data" / "questions").glob("*.yml")
+        )
+        helper_source = (FINANCIAL_ROOT / "financial_statement_helpers.py").read_text()
+
+        self.assertNotIn(".statement_user = users[i]", question_source)
+        self.assertNotIn("x.statement_user", question_source)
+        self.assertIn("def financial_statement_list_user(items):", helper_source)
+
     def test_certification_snapshot_is_compact_and_bundle_evidence_precedes_generation(self):
         all_documents = documents("main_joint_petition.yml")
         snapshots = [

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -24,6 +24,36 @@ def identified_code(filename: str, block_id: str) -> str:
 
 
 class CombinedSourceRegressionTests(unittest.TestCase):
+    def test_certification_snapshot_is_compact_and_bundle_evidence_precedes_generation(self):
+        all_documents = documents("main_joint_petition.yml")
+        snapshots = [
+            document
+            for document in all_documents
+            if document.get("event") == "combined certification snapshot"
+        ]
+        self.assertEqual(len(snapshots), 1)
+        snapshot = str(snapshots[0].get("code", ""))
+        self.assertIn('action_argument("values")', snapshot)
+        self.assertIn('action_argument("counts")', snapshot)
+        self.assertIn("json_response(certification_snapshot)", snapshot)
+
+        order_documents = [
+            document
+            for document in all_documents
+            if document.get("mandatory") is True
+            and "joint_petition_interview_order" in str(document.get("code", ""))
+        ]
+        self.assertEqual(len(order_documents), 1)
+        order = str(order_documents[0]["code"])
+        self.assertLess(
+            order.index("combined_bundle_enabled_document_names"),
+            order.index("generate_downloads_with_docx_task"),
+        )
+        bundle_names = identified_code(
+            "main_joint_petition.yml", "combined bundle enabled document names"
+        )
+        self.assertIn("al_user_bundle.enabled_documents(refresh=True)", bundle_names)
+
     def test_combined_parent_clears_standalone_document_enablement(self):
         order = identified_code("main_joint_petition.yml", "joint petition interview order")
         self.assertIn("combined_bundle_documents_normalized", order)

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -29,7 +29,7 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         snapshots = [
             document
             for document in all_documents
-            if document.get("event") == "combined certification snapshot"
+            if document.get("event") == "combined_certification_snapshot"
         ]
         self.assertEqual(len(snapshots), 1)
         snapshot = str(snapshots[0].get("code", ""))

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -77,6 +77,7 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         ]
         self.assertEqual(len(normalization_blocks), 1)
         normalization = normalization_blocks[0]
+        self.assertIn('del conditional_document.cache.enabled', normalization)
         for document_name in (
             "motion_to_amend_attachment",
             "r408_attachment",

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -250,6 +250,22 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         )
         self.assertNotIn("children.target_number = len(children)", agreement_branch)
 
+    def test_combined_parent_sets_signer_matrix_at_point_of_use(self):
+        mandatory_orders = [
+            str(document.get("code", ""))
+            for document in documents("main_joint_petition.yml")
+            if document.get("mandatory") is True
+            and "basic_questions_signature_flow" in str(document.get("code", ""))
+        ]
+        self.assertEqual(len(mandatory_orders), 1)
+        order = mandatory_orders[0]
+        self.assertIn("'attorneys[0].signature' if users[0].has_attorney", order)
+        self.assertIn("'attorneys[1].signature' if users[1].has_attorney", order)
+        self.assertLess(
+            order.index("signature_fields = ["),
+            order.index("basic_questions_signature_flow"),
+        )
+
     def test_combined_motion_order_preserves_user_object_identity(self):
         joint_order = identified_code("main_joint_petition.yml", "joint petition interview order")
         combined_order = identified_code(

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -49,10 +49,21 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             order.index("combined_bundle_enabled_document_names"),
             order.index("generate_downloads_with_docx_task"),
         )
+        self.assertLess(
+            order.index("combined_bundle_downloadable_files"),
+            order.index("divorcejointpetition_download", order.index("combined_bundle_downloadable_files")),
+        )
         bundle_names = identified_code(
             "main_joint_petition.yml", "combined bundle enabled document names"
         )
         self.assertIn("al_user_bundle.enabled_documents(refresh=True)", bundle_names)
+        downloadable_files = identified_code(
+            "main_joint_petition.yml", "combined bundle downloadable files"
+        )
+        self.assertIn(
+            "combined_bundle_downloadable_files = al_user_bundle._downloadable_files",
+            downloadable_files,
+        )
 
     def test_combined_parent_clears_standalone_document_enablement(self):
         order = identified_code("main_joint_petition.yml", "joint petition interview order")

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -65,7 +65,16 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         final_normalization = identified_code(
             "main_joint_petition.yml", "combined bundle final packet normalization"
         )
-        self.assertIn("del conditional_document.cache.enabled", final_normalization)
+        self.assertIn(
+            "conditional_document.cache.enabled = bool(final_enabled)",
+            final_normalization,
+        )
+        self.assertNotIn("del conditional_document.cache.enabled", final_normalization)
+        self.assertIn(
+            "a_divorce_agreement_Post_interview_instructions,",
+            final_normalization,
+        )
+        self.assertIn("include_separation_agreement,", final_normalization)
         self.assertIn(
             "combined_bundle_final_packet_normalized = True", final_normalization
         )
@@ -173,6 +182,27 @@ class CombinedSourceRegressionTests(unittest.TestCase):
                 "children[i].birthdate",
             },
         )
+
+        petition_order = identified_code(
+            "divorce_joint_petition.yml", "interview_order_divorcejointpetition"
+        )
+        self.assertLess(
+            petition_order.index(
+                "children.target_number = children_of_marriage_number"
+            ),
+            petition_order.index("children.gather()"),
+        )
+        combined_order = identified_code(
+            "main_joint_petition.yml", "joint petition interview order"
+        )
+        agreement_branch = combined_order.split(
+            "if include_separation_agreement:", 1
+        )[1]
+        self.assertIn(
+            "children.target_number = children_of_marriage_number",
+            agreement_branch,
+        )
+        self.assertNotIn("children.target_number = len(children)", agreement_branch)
 
     def test_combined_motion_order_preserves_user_object_identity(self):
         joint_order = identified_code("main_joint_petition.yml", "joint petition interview order")

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -69,6 +69,10 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             "conditional_document.cache.enabled = bool(final_enabled)",
             final_normalization,
         )
+        self.assertIn(
+            "conditional_document.enabled = bool(final_enabled)",
+            final_normalization,
+        )
         self.assertNotIn("del conditional_document.cache.enabled", final_normalization)
         self.assertIn(
             "a_divorce_agreement_Post_interview_instructions,",
@@ -187,6 +191,10 @@ class CombinedSourceRegressionTests(unittest.TestCase):
             "divorce_joint_petition.yml", "interview_order_divorcejointpetition"
         )
         self.assertLess(
+            petition_order.index("children.ask_number = True"),
+            petition_order.index("children.gather()"),
+        )
+        self.assertLess(
             petition_order.index(
                 "children.target_number = children_of_marriage_number"
             ),
@@ -198,6 +206,10 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         agreement_branch = combined_order.split(
             "if include_separation_agreement:", 1
         )[1]
+        self.assertIn(
+            "children.ask_number = True",
+            agreement_branch,
+        )
         self.assertIn(
             "children.target_number = children_of_marriage_number",
             agreement_branch,

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -35,6 +35,7 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         snapshot = str(snapshots[0].get("code", ""))
         self.assertIn('action_argument("values")', snapshot)
         self.assertIn('action_argument("counts")', snapshot)
+        self.assertIn("certification_value.as_serializable()", snapshot)
         self.assertIn("json_response(certification_snapshot)", snapshot)
 
         order_documents = [

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -36,6 +36,16 @@ class CombinedSourceRegressionTests(unittest.TestCase):
         self.assertNotIn("x.statement_user", question_source)
         self.assertIn("def financial_statement_list_user(items):", helper_source)
 
+    def test_financial_nested_lists_use_distinct_item_index(self):
+        shared_source = (
+            FINANCIAL_ROOT / "data" / "questions" / "financial_statement_shared.yml"
+        ).read_text()
+
+        for collection in ("motor_vehicles", "pensions", "other_assets", "liabilities"):
+            self.assertNotIn(f"users[i].{collection}[i]", shared_source)
+            self.assertIn(f"generic object: users[i].{collection}", shared_source)
+            self.assertIn(f"users[i].{collection}[j]", shared_source)
+
     def test_certification_snapshot_is_compact_and_bundle_evidence_precedes_generation(self):
         all_documents = documents("main_joint_petition.yml")
         snapshots = [

--- a/tests/certification/test_combined_source_regressions.py
+++ b/tests/certification/test_combined_source_regressions.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+HERE = Path(__file__).resolve().parent
+QUESTION_ROOT = HERE.parents[1] / "docassemble" / "MATC1ADivorceJointPetition" / "data" / "questions"
+
+
+def documents(filename: str) -> list[dict]:
+    return [
+        document
+        for document in yaml.safe_load_all((QUESTION_ROOT / filename).read_text())
+        if isinstance(document, dict)
+    ]
+
+
+def identified_code(filename: str, block_id: str) -> str:
+    for document in documents(filename):
+        if document.get("id") == block_id:
+            return str(document.get("code", ""))
+    raise AssertionError(f"missing code block {block_id}")
+
+
+class CombinedSourceRegressionTests(unittest.TestCase):
+    def test_uploaded_or_delayed_agreement_does_not_seek_built_agreement_state(self):
+        order = identified_code("main_joint_petition.yml", "joint petition interview order")
+        agreement_branch = order.split("if include_separation_agreement:", 1)[1].split(
+            "# Findings and Determinations", 1
+        )[0]
+        self.assertIn("provisions_that_merge.all_false()", agreement_branch)
+        self.assertIn("set_petition_merger_survival_from_agreement = True", agreement_branch)
+
+        competing_definitions = [
+            document
+            for document in documents("main_joint_petition.yml")
+            if "request_merge_agreement" in str(document.get("code", ""))
+            and document.get("id") != "joint petition interview order"
+        ]
+        self.assertEqual(competing_definitions, [])
+
+    def test_r408_order_seeks_field_variables_not_question_ids(self):
+        order = identified_code("r408_report_of_absolute_divorce.yml", "interview order r408")
+        self.assertNotIn("\n    r408_demographics\n", order)
+        self.assertNotIn("\n    r408_prior_marriages_and_birth_names\n", order)
+        self.assertNotIn("\n    r408_additional_children_info\n", order)
+        for variable in (
+            "users1_gender",
+            "users2_gender",
+            "users1_ssn_last_four",
+            "users2_ssn_last_four",
+            "users1_marriage_number",
+            "users2_marriage_number",
+            "users1_name_last_at_birth",
+            "users2_name_last_at_birth",
+            "r408_addendum",
+        ):
+            self.assertIn(variable, order)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from generate_scenarios import expected_terminal_evidence, generate
+from generate_scenarios import expected_cardinalities, expected_terminal_evidence, generate
 
 
 HERE = Path(__file__).resolve().parent
@@ -47,24 +47,34 @@ class ScenarioGenerationTests(unittest.TestCase):
         self.assertTrue(evidence["include_findings_and_determinations"])
         self.assertFalse(evidence["needs_late_marriage_certificate_motion"])
 
-    def test_every_dimension_value_appears_in_defaults_or_an_override(self):
-        observed = {key: {self._freeze(value)} for key, value in self.model["default_variables"].items()}
-        for path in self.model["modeled_paths"]:
-            for key, value in path.get("overrides", {}).items():
-                observed.setdefault(key, set()).add(self._freeze(value))
+    def test_cardinality_evidence_is_derived_from_path_inputs(self):
+        evidence = expected_cardinalities(
+            self.model,
+            {"children_of_marriage_number": 5},
+        )
+        self.assertEqual(evidence["users"]["expected"], 2)
+        self.assertEqual(evidence["children"]["expected"], 5)
 
-        # Derived checkbox booleans are covered by the explicit checkbox paths.
-        derived = {"divorce_affirm", "joint_petition_affirm"}
+    def test_every_dimension_value_appears_in_defaults_or_an_override(self):
+        observed = {}
+        self._record_values(observed, self.model["default_variables"])
+        for path in self.model["modeled_paths"]:
+            self._record_values(observed, path.get("overrides", {}))
+
         for variable, values in self.model["dimensions"].items():
-            if variable in derived:
-                continue
-            if variable == "notarize_affirm":
-                continue
             expected = {self._freeze(value) for value in values}
             self.assertTrue(
                 expected.issubset(observed.get(variable, set())),
                 f"missing modeled values for {variable}: {expected - observed.get(variable, set())}",
             )
+
+    @classmethod
+    def _record_values(cls, observed, values, prefix=""):
+        for key, value in values.items():
+            variable = f"{prefix}.{key}" if prefix else key
+            observed.setdefault(variable, set()).add(cls._freeze(value))
+            if isinstance(value, dict) and "$file" not in value and "$sequence" not in value:
+                cls._record_values(observed, value, variable)
 
     @staticmethod
     def _freeze(value):

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from generate_scenarios import generate
+from generate_scenarios import expected_terminal_evidence, generate
 
 
 HERE = Path(__file__).resolve().parent
@@ -24,7 +24,28 @@ class ScenarioGenerationTests(unittest.TestCase):
             for path in paths:
                 scenario = json.loads(path.read_text())
                 self.assertTrue(scenario["expected_terminal_ids"])
+                self.assertTrue(scenario["expected_terminal_evidence"])
                 self.assertTrue(scenario["probe_events"])
+
+    def test_bundle_evidence_is_derived_from_path_inputs(self):
+        evidence = expected_terminal_evidence({
+            "children_of_marriage": True,
+            "has_existing_1b_action": False,
+            "financial_statement_scope": "spouse_1_only",
+            "separation_agreement_format": "interview",
+            "csg_worksheet_path": "interview",
+            "child_support_deviation": True,
+            "marriage_certificate_upload": "uploaded.pdf",
+        })
+        self.assertTrue(evidence["include_r408"])
+        self.assertTrue(evidence["include_care_or_custody_affidavit"])
+        self.assertTrue(evidence["include_child_support_guidelines_worksheet"])
+        self.assertTrue(evidence["include_financial_statement"])
+        self.assertTrue(evidence["include_financial_statement_spouse_1"])
+        self.assertFalse(evidence["include_financial_statement_spouse_2"])
+        self.assertTrue(evidence["include_separation_agreement"])
+        self.assertTrue(evidence["include_findings_and_determinations"])
+        self.assertFalse(evidence["needs_late_marriage_certificate_motion"])
 
     def test_every_dimension_value_appears_in_defaults_or_an_override(self):
         observed = {key: {self._freeze(value)} for key, value in self.model["default_variables"].items()}

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -51,9 +51,11 @@ class ScenarioGenerationTests(unittest.TestCase):
         evidence = expected_cardinalities(
             self.model,
             {"children_of_marriage_number": 5},
+            {"other_care_custody_proceedings": 2},
         )
         self.assertEqual(evidence["users"]["expected"], 2)
         self.assertEqual(evidence["children"]["expected"], 5)
+        self.assertEqual(evidence["other_care_custody_proceedings"]["expected"], 2)
 
     def test_every_dimension_value_appears_in_defaults_or_an_override(self):
         observed = {}

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -3,9 +3,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import yaml
+from yaml.constructor import ConstructorError
 
 from generate_scenarios import expected_cardinalities, expected_terminal_evidence, generate
+from model_loader import load_model
 
 
 HERE = Path(__file__).resolve().parent
@@ -14,7 +15,7 @@ HERE = Path(__file__).resolve().parent
 class ScenarioGenerationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = yaml.safe_load((HERE / "coverage_model.yml").read_text())
+        cls.model = load_model(HERE / "coverage_model.yml")
 
     def test_every_declared_path_is_materialized(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -26,6 +27,13 @@ class ScenarioGenerationTests(unittest.TestCase):
                 self.assertTrue(scenario["expected_terminal_ids"])
                 self.assertTrue(scenario["expected_terminal_evidence"])
                 self.assertTrue(scenario["probe_events"])
+
+    def test_model_loader_rejects_duplicate_keys(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model_path = Path(directory) / "ambiguous.yml"
+            model_path.write_text("dimensions:\n  branch: true\n  branch: false\n")
+            with self.assertRaises(ConstructorError):
+                load_model(model_path)
 
     def test_bundle_evidence_is_derived_from_path_inputs(self):
         evidence = expected_terminal_evidence({

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -34,6 +34,26 @@ class ScenarioGenerationTests(unittest.TestCase):
                 self.assertTrue(scenario["expected_bundle_documents"])
                 self.assertTrue(scenario["probe_events"])
 
+    def test_financial_paths_explicitly_choose_schedule_scope(self):
+        with tempfile.TemporaryDirectory() as directory:
+            paths = generate(self.model, Path(directory))
+            for path in paths:
+                scenario = json.loads(path.read_text())
+                if scenario["family"] != "financial":
+                    continue
+                variables = scenario["variables"]
+                scope = variables["financial_statement_scope"]
+                selected_indexes = []
+                if scope in ("spouse_1_only", "both"):
+                    selected_indexes.append(0)
+                if scope in ("spouse_2_only", "both"):
+                    selected_indexes.append(1)
+                for index in selected_indexes:
+                    self.assertIn(
+                        f"users[{index}].has_self_employment_income", variables
+                    )
+                    self.assertIn(f"users[{index}].has_rental_income", variables)
+
     def test_model_loader_rejects_duplicate_keys(self):
         with tempfile.TemporaryDirectory() as directory:
             model_path = Path(directory) / "ambiguous.yml"

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -30,9 +30,14 @@ class ScenarioGenerationTests(unittest.TestCase):
             for path in paths:
                 scenario = json.loads(path.read_text())
                 self.assertTrue(scenario["expected_terminal_ids"])
-                self.assertTrue(scenario["expected_terminal_evidence"])
-                self.assertTrue(scenario["expected_bundle_documents"])
-                self.assertTrue(scenario["probe_events"])
+                if scenario["terminal_assertions"]:
+                    self.assertTrue(scenario["expected_terminal_evidence"])
+                    self.assertTrue(scenario["expected_bundle_documents"])
+                    self.assertTrue(scenario["probe_events"])
+                else:
+                    self.assertFalse(scenario["expected_terminal_evidence"])
+                    self.assertFalse(scenario["expected_bundle_documents"])
+                    self.assertFalse(scenario["expected_cardinalities"])
 
     def test_financial_paths_explicitly_choose_schedule_scope(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 from yaml.constructor import ConstructorError
 
-from generate_scenarios import expected_cardinalities, expected_terminal_evidence, generate
+from generate_scenarios import (
+    expected_bundle_documents,
+    expected_cardinalities,
+    expected_terminal_evidence,
+    generate,
+)
 from model_loader import load_model
 
 
@@ -26,6 +31,7 @@ class ScenarioGenerationTests(unittest.TestCase):
                 scenario = json.loads(path.read_text())
                 self.assertTrue(scenario["expected_terminal_ids"])
                 self.assertTrue(scenario["expected_terminal_evidence"])
+                self.assertTrue(scenario["expected_bundle_documents"])
                 self.assertTrue(scenario["probe_events"])
 
     def test_model_loader_rejects_duplicate_keys(self):
@@ -64,6 +70,27 @@ class ScenarioGenerationTests(unittest.TestCase):
         self.assertEqual(evidence["users"]["expected"], 2)
         self.assertEqual(evidence["children"]["expected"], 5)
         self.assertEqual(evidence["other_care_custody_proceedings"]["expected"], 2)
+
+    def test_exact_bundle_membership_is_derived_from_path_inputs(self):
+        evidence = expected_bundle_documents({
+            "children_of_marriage": True,
+            "has_existing_1b_action": False,
+            "financial_statement_scope": "spouse_1_only",
+            "users[0].gross_annual_income": 75000,
+            "users[0].has_self_employment_income": True,
+            "separation_agreement_format": "interview",
+            "csg_worksheet_path": "interview",
+            "child_support_deviation": True,
+            "marriage_certificate_upload": "uploaded.pdf",
+            "ask_if_qualifies_for_fee_waiver": False,
+        })
+        self.assertTrue(evidence["users[0].financial_statement_long_attachment"])
+        self.assertFalse(evidence["users[0].financial_statement_short_attachment"])
+        self.assertTrue(evidence["users[0].financial_statement_schedule_a_attachment"])
+        self.assertFalse(evidence["users[1].financial_statement_long_attachment"])
+        self.assertTrue(evidence["a_divorce_agreement_attachment"])
+        self.assertTrue(evidence["cjd_305_attachment"])
+        self.assertFalse(evidence["jointmotiontofilemarriagecertificatelate_attachment"])
 
     def test_every_dimension_value_appears_in_defaults_or_an_override(self):
         observed = {}

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -1,0 +1,57 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from generate_scenarios import generate
+
+
+HERE = Path(__file__).resolve().parent
+
+
+class ScenarioGenerationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = yaml.safe_load((HERE / "coverage_model.yml").read_text())
+
+    def test_every_declared_path_is_materialized(self):
+        with tempfile.TemporaryDirectory() as directory:
+            paths = generate(self.model, Path(directory))
+            self.assertEqual(len(paths), len(self.model["modeled_paths"]))
+            self.assertEqual(len(paths), len({path.name for path in paths}))
+            for path in paths:
+                scenario = json.loads(path.read_text())
+                self.assertTrue(scenario["expected_terminal_ids"])
+
+    def test_every_dimension_value_appears_in_defaults_or_an_override(self):
+        observed = {key: {self._freeze(value)} for key, value in self.model["default_variables"].items()}
+        for path in self.model["modeled_paths"]:
+            for key, value in path.get("overrides", {}).items():
+                observed.setdefault(key, set()).add(self._freeze(value))
+
+        # Derived checkbox booleans are covered by the explicit checkbox paths.
+        derived = {"divorce_affirm", "joint_petition_affirm"}
+        for variable, values in self.model["dimensions"].items():
+            if variable in derived:
+                continue
+            if variable == "notarize_affirm":
+                continue
+            expected = {self._freeze(value) for value in values}
+            self.assertTrue(
+                expected.issubset(observed.get(variable, set())),
+                f"missing modeled values for {variable}: {expected - observed.get(variable, set())}",
+            )
+
+    @staticmethod
+    def _freeze(value):
+        if isinstance(value, dict):
+            return tuple(sorted((key, ScenarioGenerationTests._freeze(item)) for key, item in value.items()))
+        if isinstance(value, list):
+            return tuple(ScenarioGenerationTests._freeze(item) for item in value)
+        return value
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/certification/test_generate_scenarios.py
+++ b/tests/certification/test_generate_scenarios.py
@@ -24,6 +24,7 @@ class ScenarioGenerationTests(unittest.TestCase):
             for path in paths:
                 scenario = json.loads(path.read_text())
                 self.assertTrue(scenario["expected_terminal_ids"])
+                self.assertTrue(scenario["probe_events"])
 
     def test_every_dimension_value_appears_in_defaults_or_an_override(self):
         observed = {key: {self._freeze(value)} for key, value in self.model["default_variables"].items()}

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -27,14 +27,20 @@ def limits(**overrides):
 
 
 class FakeClient:
-    def __init__(self, questions):
+    def __init__(self, questions, actions=None):
         self.questions = iter(questions)
+        self.actions = actions or {}
+        self.pending_action = None
 
     def new_session(self, interview):
         return "session", "", interview
 
     def question(self, interview, session, secret):
-        value = next(self.questions)
+        if self.pending_action:
+            value = self.actions[self.pending_action]
+            self.pending_action = None
+        else:
+            value = next(self.questions)
         if isinstance(value, Exception):
             raise value
         return value
@@ -42,15 +48,35 @@ class FakeClient:
     def answer(self, interview, session, secret, variables, event_list=None):
         return {}
 
+    def variables(self, interview, session, secret):
+        return {"divorcejointpetition_downloads_ready": True}
+
+    def action(self, interview, session, secret, action, arguments=None):
+        self.pending_action = action
+
     def delete(self, interview, session, secret):
         return None
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_settrue_field_defaults_to_boolean_true(self):
+        question = {
+            "questionType": "settrue",
+            "fields": [{"variable_name": "intro_complete", "datatype": "text"}],
+        }
+        self.assertEqual(build_answer(question, {}), {"intro_complete": True})
+
     def test_string_false_show_if_value_keeps_visible_field(self):
         question = {
             "fields": [
                 {"variable_name": "documented", "datatype": "boolean"},
+                {
+                    "variable_name": "format",
+                    "datatype": "radio",
+                    "choices": [{"label": "Upload", "value": "upload"}],
+                    "show_if_var": "documented",
+                    "show_if_val": "True",
+                },
                 {
                     "variable_name": "format",
                     "datatype": "radio",
@@ -111,6 +137,7 @@ class RuntimeDriverTests(unittest.TestCase):
         result = run_scenario(FakeClient([terminal]), SCENARIO, limits())
         self.assertEqual(result["status"], "pass")
         self.assertIsNone(result["failure"])
+        self.assertTrue(result["terminal_evidence"]["divorcejointpetition_downloads_ready"])
 
     def test_unexpected_normal_terminal_fails(self):
         terminal = {
@@ -121,6 +148,32 @@ class RuntimeDriverTests(unittest.TestCase):
         scenario = {**SCENARIO, "expected_terminal_ids": ["download divorce joint petition"]}
         result = run_scenario(FakeClient([terminal]), scenario, limits())
         self.assertEqual(result["failure"], "unexpected_terminal")
+
+    def test_declared_event_probe_adds_its_screen_to_coverage(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        review = {
+            "id": "divorce joint petition review screen",
+            "questionType": "review",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "probe_events": [{
+                "event": "review_divorcejointpetition",
+                "expected_id": "divorce joint petition review screen",
+            }],
+        }
+        result = run_scenario(
+            FakeClient([terminal], {"review_divorcejointpetition": review}),
+            scenario,
+            limits(),
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertIn("divorce joint petition review screen", result["seen_screen_ids"])
 
     @patch("runtime_driver.time.sleep", return_value=None)
     def test_download_waiting_screen_is_not_a_terminal_pass(self, _sleep):

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -6,9 +6,12 @@ import requests
 from runtime_driver import (
     Limits,
     build_answer,
+    field_within_cardinalities,
     run_scenario,
     serialized_collection_count,
+    serialized_object_choices,
     serialized_path_cardinality,
+    serialized_path_value,
 )
 
 
@@ -105,6 +108,64 @@ class RuntimeDriverTests(unittest.TestCase):
             [0, 0],
         )
 
+    def test_serialized_path_value_resolves_nested_list_member(self):
+        child = {"_class": "example.Child", "instanceName": "children[1]"}
+        variables = {"children": {"elements": [{}, child]}}
+        self.assertEqual(serialized_path_value(variables, "children[1]"), child)
+
+    def test_rendered_list_collect_rows_stop_at_modeled_cardinality(self):
+        cardinalities = {
+            "children": {"variable": "children", "expected": 2},
+        }
+        self.assertTrue(field_within_cardinalities("children[1].name.first", cardinalities))
+        self.assertFalse(field_within_cardinalities("children[2].name.first", cardinalities))
+
+    def test_nested_rendered_rows_stop_at_each_parent_cardinality(self):
+        cardinalities = {
+            "addresses": {
+                "variable": "children[*].previous_addresses",
+                "expected": [2, 0],
+            },
+        }
+        self.assertTrue(
+            field_within_cardinalities(
+                "children[0].previous_addresses[1].address",
+                cardinalities,
+            )
+        )
+        self.assertFalse(
+            field_within_cardinalities(
+                "children[1].previous_addresses[0].address",
+                cardinalities,
+            )
+        )
+
+    def test_object_choices_are_serialized_as_a_gathered_list(self):
+        child = {
+            "_class": "docassemble.AssemblyLine.al_general.ALIndividual",
+            "instanceName": "children[0]",
+            "letter": "A",
+        }
+        target = {
+            "_class": "docassemble.AssemblyLine.al_general.ALPeopleList",
+            "instanceName": "proceedings[0].children",
+            "elements": [],
+        }
+        variables = {
+            "children": {"elements": [child]},
+            "proceedings": {"elements": [{"children": target}]},
+        }
+        result = serialized_object_choices(
+            "proceedings[0].children",
+            [{"label": "Child", "value": "children[0]"}],
+            ["children[0]"],
+            variables,
+        )
+        self.assertEqual(result["_class"], target["_class"])
+        self.assertEqual(result["elements"], [child])
+        self.assertTrue(result["gathered"])
+        self.assertFalse(result["there_is_another"])
+
     def test_settrue_field_defaults_to_boolean_true(self):
         question = {
             "questionType": "settrue",
@@ -119,6 +180,50 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertEqual(
             build_answer(question, {}),
             {"users[0].ssn": "123-45-6789"},
+        )
+
+    def test_yesnomaybe_defaults_to_boolean_false_and_hides_followup(self):
+        question = {
+            "event_list": ["children[0].gals.target_number"],
+            "fields": [
+                {
+                    "variable_name": "children[i].has_gal",
+                    "datatype": "threestate",
+                    "inputtype": "yesnomaybe",
+                },
+                {
+                    "variable_name": "children[i].gals.target_number",
+                    "datatype": "integer",
+                    "show_if_var": "children[i].has_gal",
+                    "show_if_val": "True",
+                },
+            ],
+        }
+        self.assertEqual(
+            build_answer(question, {}),
+            {"children[0].has_gal": False},
+        )
+
+    def test_build_answer_omits_rows_beyond_modeled_count(self):
+        question = {
+            "fields": [
+                {"variable_name": "children[0].name.first", "datatype": "text"},
+                {"variable_name": "children[1].name.first", "datatype": "text"},
+                {"variable_name": "children[2].name.first", "datatype": "text"},
+            ],
+        }
+        self.assertEqual(
+            build_answer(
+                question,
+                {},
+                expected_cardinalities={
+                    "children": {"variable": "children", "expected": 2},
+                },
+            ),
+            {
+                "children[0].name.first": "Test",
+                "children[1].name.first": "Test",
+            },
         )
 
     def test_string_false_show_if_value_keeps_visible_field(self):
@@ -385,6 +490,35 @@ class RuntimeDriverTests(unittest.TestCase):
         )
         self.assertEqual(result["status"], "pass")
         self.assertEqual(result["cardinality_evidence"]["children"]["observed"], 0)
+
+    def test_absent_wildcard_collection_counts_as_empty_vector(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "expected_cardinalities": {
+                "proceeding_other_parties": {
+                    "variable": "proceedings[*].other_parties",
+                    "expected": [],
+                },
+            },
+        }
+        result = run_scenario(
+            FakeClient(
+                [terminal],
+                terminal_variables={"divorcejointpetition_downloads_ready": True},
+            ),
+            scenario,
+            limits(),
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(
+            result["cardinality_evidence"]["proceeding_other_parties"]["observed"],
+            [],
+        )
 
     def test_declared_event_probe_adds_its_screen_to_coverage(self):
         terminal = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -93,6 +93,25 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_client_uses_valid_snapshot_event_identifier(self):
+        client = Client("http://server", "key", 10)
+        client.http = Mock()
+        client.http.post.return_value = Mock(
+            json=Mock(return_value={"answer": True})
+        )
+
+        result = client.snapshot(
+            "docassemble.example:data/questions/main.yml",
+            "session",
+            "secret",
+            values=["answer"],
+        )
+
+        self.assertEqual(result, {"answer": True})
+        post_data = client.http.post.call_args.kwargs["data"]
+        self.assertEqual(post_data["action"], "combined_certification_snapshot")
+        self.assertNotIn(" ", post_data["action"])
+
     def test_client_saves_answer_before_fetching_next_question(self):
         client = Client("http://server", "key", 10)
         client.http = Mock()

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -1,0 +1,163 @@
+import unittest
+from unittest.mock import patch
+
+import requests
+
+from runtime_driver import Limits, build_answer, run_scenario
+
+
+SCENARIO = {
+    "name": "fake",
+    "interview": "docassemble.fake:data/questions/main.yml",
+    "variables": {},
+}
+
+
+def limits(**overrides):
+    values = {
+        "request_timeout": 1,
+        "scenario_timeout": 10,
+        "max_steps": 10,
+        "max_same_screen": 2,
+        "max_same_state_visits": 2,
+        "download_task_timeout": 5,
+    }
+    values.update(overrides)
+    return Limits(**values)
+
+
+class FakeClient:
+    def __init__(self, questions):
+        self.questions = iter(questions)
+
+    def new_session(self, interview):
+        return "session", "", interview
+
+    def question(self, interview, session, secret):
+        value = next(self.questions)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def answer(self, interview, session, secret, variables, event_list=None):
+        return {}
+
+    def delete(self, interview, session, secret):
+        return None
+
+
+class RuntimeDriverTests(unittest.TestCase):
+    def test_string_false_show_if_value_keeps_visible_field(self):
+        question = {
+            "fields": [
+                {"variable_name": "documented", "datatype": "boolean"},
+                {
+                    "variable_name": "format",
+                    "datatype": "radio",
+                    "choices": [{"label": "Later", "value": "wait"}],
+                    "show_if_var": "documented",
+                    "show_if_val": "False",
+                },
+            ]
+        }
+        answer = build_answer(question, {"documented": False, "format": "wait"})
+        self.assertEqual(answer, {"documented": False, "format": "wait"})
+
+    def test_consecutive_repeated_state_is_a_hang_failure(self):
+        stuck = {
+            "id": "same screen",
+            "questionType": "question",
+            "question_variable_name": "continue_here",
+            "fields": [],
+        }
+        result = run_scenario(FakeClient([stuck, stuck, stuck]), SCENARIO, limits())
+        self.assertEqual(result["failure"], "consecutive_repeated_state")
+
+    def test_request_timeout_is_a_hang_failure(self):
+        result = run_scenario(
+            FakeClient([requests.Timeout("server stopped responding")]),
+            SCENARIO,
+            limits(),
+        )
+        self.assertEqual(result["failure"], "request_timeout")
+
+    def test_error_screen_fails(self):
+        error = {
+            "id": "custom error action",
+            "questionType": "deadend",
+            "questionText": "There was an error",
+            "subquestionText": "NameError: missing_variable",
+        }
+        result = run_scenario(FakeClient([error]), SCENARIO, limits())
+        self.assertEqual(result["failure"], "error_screen")
+
+    def test_undefined_variable_records_the_exact_name(self):
+        error = {
+            "questionType": "undefined_variable",
+            "variable": "missing_variable",
+            "message_log": [{"priority": "error", "message": "not defined"}],
+        }
+        result = run_scenario(FakeClient([error]), SCENARIO, limits())
+        self.assertEqual(result["failure"], "error_screen")
+        self.assertEqual(result["steps"][0]["undefined_variable"], "missing_variable")
+        self.assertEqual(result["steps"][0]["message_log"][0]["priority"], "error")
+
+    def test_download_screen_passes(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        result = run_scenario(FakeClient([terminal]), SCENARIO, limits())
+        self.assertEqual(result["status"], "pass")
+        self.assertIsNone(result["failure"])
+
+    def test_unexpected_normal_terminal_fails(self):
+        terminal = {
+            "id": "not the expected ending",
+            "questionType": "deadend",
+            "fields": [],
+        }
+        scenario = {**SCENARIO, "expected_terminal_ids": ["download divorce joint petition"]}
+        result = run_scenario(FakeClient([terminal]), scenario, limits())
+        self.assertEqual(result["failure"], "unexpected_terminal")
+
+    @patch("runtime_driver.time.sleep", return_value=None)
+    def test_download_waiting_screen_is_not_a_terminal_pass(self, _sleep):
+        waiting = {
+            "id": "waiting screen",
+            "questionType": "event",
+            "event_list": ["al_download_waiting_screen"],
+            "fields": [],
+        }
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        result = run_scenario(
+            FakeClient([waiting, waiting, terminal]),
+            SCENARIO,
+            limits(max_steps=4),
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual([step["id"] for step in result["steps"]], [
+            "waiting screen",
+            "waiting screen",
+            "download divorce joint petition",
+        ])
+
+    @patch("runtime_driver.time.monotonic", side_effect=[0, 0, 0, 6, 6])
+    def test_download_waiting_screen_has_a_specific_timeout(self, _monotonic):
+        waiting = {
+            "id": "waiting screen",
+            "questionType": "event",
+            "event_list": ["al_download_waiting_screen"],
+            "fields": [],
+        }
+        result = run_scenario(FakeClient([waiting]), SCENARIO, limits())
+        self.assertEqual(result["failure"], "download_task_timeout")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -74,6 +74,15 @@ class RuntimeDriverTests(unittest.TestCase):
         }
         self.assertEqual(build_answer(question, {}), {"intro_complete": True})
 
+    def test_ssn_fields_use_a_valid_representative(self):
+        question = {
+            "fields": [{"variable_name": "users[0].ssn", "datatype": "ssn"}],
+        }
+        self.assertEqual(
+            build_answer(question, {}),
+            {"users[0].ssn": "123-45-6789"},
+        )
+
     def test_string_false_show_if_value_keeps_visible_field(self):
         question = {
             "fields": [
@@ -96,6 +105,21 @@ class RuntimeDriverTests(unittest.TestCase):
         }
         answer = build_answer(question, {"documented": False, "format": "wait"})
         self.assertEqual(answer, {"documented": False, "format": "wait"})
+
+    def test_expression_show_if_does_not_hide_server_visible_fields(self):
+        question = {
+            "fields": [
+                {
+                    "variable_name": "users1_gender",
+                    "datatype": "text",
+                    "inputtype": "radio",
+                    "choices": [{"label": "Male", "value": "male"}],
+                    "show_if_var": 'not showifdef("users1_gender")',
+                    "show_if_val": "True",
+                }
+            ],
+        }
+        self.assertEqual(build_answer(question, {}), {"users1_gender": "male"})
 
     def test_unmodeled_list_controls_default_to_no(self):
         question = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -482,6 +482,34 @@ class RuntimeDriverTests(unittest.TestCase):
         answer = build_answer(question, {"documented": False, "format": "wait"})
         self.assertEqual(answer, {"documented": False, "format": "wait"})
 
+    def test_hide_if_field_is_kept_when_condition_does_not_match(self):
+        question = {
+            "fields": [
+                {
+                    "variable_name": "case_status",
+                    "datatype": "radio",
+                    "choices": [
+                        {"label": "Restraining order", "value": "restraining"}
+                    ],
+                },
+                {
+                    "variable_name": "user_role",
+                    "datatype": "radio",
+                    "choices": [{"label": "Party", "value": "party"}],
+                    "show_if_sign": 0,
+                    "show_if_var": "case_status",
+                    "show_if_val": "adoption",
+                },
+            ]
+        }
+        self.assertEqual(
+            build_answer(
+                question,
+                {"case_status": "restraining", "user_role": "party"},
+            ),
+            {"case_status": "restraining", "user_role": "party"},
+        )
+
     def test_expression_show_if_does_not_hide_server_visible_fields(self):
         question = {
             "fields": [

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -1,9 +1,10 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import requests
 
 from runtime_driver import (
+    Client,
     Limits,
     build_answer,
     field_within_cardinalities,
@@ -93,6 +94,28 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_client_saves_answer_before_fetching_next_question(self):
+        client = Client("http://server", "key", 10)
+        client.http = Mock()
+        client.http.post.return_value = Mock()
+        client.http.get.return_value = Mock(
+            json=Mock(return_value={"id": "next"})
+        )
+
+        result = client.answer(
+            "docassemble.example:data/questions/main.yml",
+            "session",
+            "secret",
+            {"answer": True},
+            ["answer"],
+        )
+
+        self.assertEqual(result, {"id": "next"})
+        post_data = client.http.post.call_args.kwargs["data"]
+        self.assertEqual(post_data["question"], 0)
+        self.assertEqual(post_data["variables"], '{"answer":true}')
+        client.http.get.assert_called_once()
+
     def test_bundle_membership_mismatch_fails_terminal(self):
         terminal = {
             "id": "download divorce joint petition",
@@ -123,7 +146,7 @@ class RuntimeDriverTests(unittest.TestCase):
             terminal_variables={
                 "divorcejointpetition_downloads_ready": True,
                 "combined_bundle_enabled_document_names": ["required_attachment"],
-                "al_user_bundle._downloadable_files": [
+                "combined_bundle_downloadable_files": [
                     [{"title": "Required", "pdf": file_value}],
                     None,
                     None,

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -8,6 +8,7 @@ from runtime_driver import (
     Limits,
     build_answer,
     field_within_cardinalities,
+    question_variable,
     question_source_file,
     run_scenario,
     serialized_collection_count,
@@ -93,6 +94,50 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_question_variable_prefers_concrete_event_for_generic_screen(self):
+        question = {
+            "question_variable_name": "users[i].income_schedule_triggers",
+            "event_list": ["users[1].income_schedule_triggers"],
+        }
+
+        self.assertEqual(
+            question_variable(question),
+            "users[1].income_schedule_triggers",
+        )
+
+    def test_generic_screen_uses_modeled_values_for_concrete_person(self):
+        question = {
+            "question_variable_name": "users[i].income_schedule_triggers",
+            "event_list": ["users[1].income_schedule_triggers"],
+            "fields": [
+                {
+                    "variable_name": "users[i].has_self_employment_income",
+                    "datatype": "boolean",
+                    "inputtype": "yesnoradio",
+                },
+                {
+                    "variable_name": "users[i].has_rental_income",
+                    "datatype": "boolean",
+                    "inputtype": "yesnoradio",
+                },
+            ],
+        }
+
+        self.assertEqual(
+            build_answer(
+                question,
+                {
+                    "users[1].has_self_employment_income": False,
+                    "users[1].has_rental_income": False,
+                },
+            ),
+            {
+                "users[1].has_self_employment_income": False,
+                "users[1].has_rental_income": False,
+                "users[1].income_schedule_triggers": True,
+            },
+        )
+
     def test_client_uses_valid_snapshot_event_identifier(self):
         client = Client("http://server", "key", 10)
         client.http = Mock()

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -10,6 +10,7 @@ from runtime_driver import (
     question_source_file,
     run_scenario,
     serialized_collection_count,
+    serialized_bundle_evidence,
     serialized_object_choices,
     serialized_path_cardinality,
     serialized_path_value,
@@ -81,6 +82,52 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_serialized_bundle_evidence_records_exact_generated_files(self):
+        bundle = {
+            "_class": "docassemble.AssemblyLine.al_document.ALDocumentBundle",
+            "elements": [
+                {
+                    "instanceName": "included_attachment",
+                    "always_enabled": False,
+                    "cache": {"enabled": True},
+                    "elements": {
+                        "preview": {
+                            "pdf": {
+                                "_class": "docassemble.base.util.DAFile",
+                                "filename": "included.pdf",
+                                "extension": "pdf",
+                                "ok": True,
+                                "file_info": {"pages": 2},
+                            }
+                        }
+                    },
+                },
+                {
+                    "instanceName": "excluded_attachment",
+                    "always_enabled": False,
+                    "cache": {"enabled": False},
+                    "elements": {},
+                },
+            ],
+        }
+        evidence = serialized_bundle_evidence(bundle)
+        self.assertTrue(evidence["included_attachment"]["generated"])
+        self.assertEqual(evidence["included_attachment"]["files"][0]["pages"], 2)
+        self.assertFalse(evidence["excluded_attachment"]["generated"])
+
+    def test_bundle_membership_mismatch_fails_terminal(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "expected_bundle_documents": {"required_attachment": True},
+        }
+        result = run_scenario(FakeClient([terminal]), scenario, limits())
+        self.assertEqual(result["failure"], "bundle_document_mismatch")
+
     def test_question_source_file_uses_included_file_history(self):
         question = {
             "source": {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import requests
 
-from runtime_driver import Limits, build_answer, run_scenario
+from runtime_driver import Limits, build_answer, run_scenario, serialized_collection_count
 
 
 SCENARIO = {
@@ -27,9 +27,12 @@ def limits(**overrides):
 
 
 class FakeClient:
-    def __init__(self, questions, actions=None):
+    def __init__(self, questions, actions=None, terminal_variables=None):
         self.questions = iter(questions)
         self.actions = actions or {}
+        self.terminal_variables = terminal_variables or {
+            "divorcejointpetition_downloads_ready": True,
+        }
         self.pending_action = None
 
     def new_session(self, interview):
@@ -57,7 +60,7 @@ class FakeClient:
         return {}
 
     def variables(self, interview, session, secret):
-        return {"divorcejointpetition_downloads_ready": True}
+        return self.terminal_variables
 
     def action(self, interview, session, secret, action, arguments=None):
         self.pending_action = action
@@ -67,6 +70,14 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_serialized_collection_count(self):
+        self.assertEqual(
+            serialized_collection_count({"_class": "DAList", "elements": [{}, {}]}),
+            2,
+        )
+        self.assertEqual(serialized_collection_count([]), 0)
+        self.assertIsNone(serialized_collection_count("not a collection"))
+
     def test_settrue_field_defaults_to_boolean_true(self):
         question = {
             "questionType": "settrue",
@@ -181,6 +192,34 @@ class RuntimeDriverTests(unittest.TestCase):
         result = run_scenario(FakeClient([stuck, stuck, stuck]), SCENARIO, limits())
         self.assertEqual(result["failure"], "consecutive_repeated_state")
 
+    def test_advancing_modeled_list_sequence_is_not_a_false_hang(self):
+        another = {
+            "id": "another item",
+            "questionType": "question",
+            "fields": [{
+                "variable_name": "items.there_is_another",
+                "datatype": "yesnoradio",
+            }],
+        }
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "variables": {
+                "items.there_is_another": {"$sequence": [True, True, False]},
+            },
+        }
+        result = run_scenario(
+            FakeClient([another, another, another, terminal]),
+            scenario,
+            limits(max_steps=5),
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertIsNone(result["failure"])
+
     def test_request_timeout_is_a_hang_failure(self):
         result = run_scenario(
             FakeClient([requests.Timeout("server stopped responding")]),
@@ -246,6 +285,32 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertEqual(
             result["terminal_evidence_mismatches"]["include_financial_statement"],
             {"expected": True, "observed": "<missing>"},
+        )
+
+    def test_terminal_cardinality_mismatch_fails(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "expected_cardinalities": {
+                "children": {"variable": "children", "expected": 2},
+            },
+        }
+        client = FakeClient(
+            [terminal],
+            terminal_variables={
+                "divorcejointpetition_downloads_ready": True,
+                "children": {"_class": "DAList", "elements": [{}]},
+            },
+        )
+        result = run_scenario(client, scenario, limits())
+        self.assertEqual(result["failure"], "cardinality_evidence_mismatch")
+        self.assertEqual(
+            result["cardinality_evidence_mismatches"]["children"]["observed"],
+            1,
         )
 
     def test_declared_event_probe_adds_its_screen_to_coverage(self):

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -45,7 +45,15 @@ class FakeClient:
             raise value
         return value
 
-    def answer(self, interview, session, secret, variables, event_list=None):
+    def answer(
+        self,
+        interview,
+        session,
+        secret,
+        variables,
+        event_list=None,
+        question_name=None,
+    ):
         return {}
 
     def variables(self, interview, session, secret):
@@ -88,6 +96,44 @@ class RuntimeDriverTests(unittest.TestCase):
         }
         answer = build_answer(question, {"documented": False, "format": "wait"})
         self.assertEqual(answer, {"documented": False, "format": "wait"})
+
+    def test_unmodeled_list_controls_default_to_no(self):
+        question = {
+            "fields": [{
+                "variable_name": "children[0].previous_addresses.there_is_another",
+                "datatype": "yesnoradio",
+            }]
+        }
+        self.assertEqual(
+            build_answer(question, {}),
+            {"children[0].previous_addresses.there_is_another": False},
+        )
+
+    def test_index_normalized_modeled_answer_applies_to_each_list_member(self):
+        question = {
+            "fields": [{
+                "variable_name": "children[2].previous_addresses.there_are_any",
+                "datatype": "yesnoradio",
+            }]
+        }
+        self.assertEqual(
+            build_answer(question, {"children[i].previous_addresses.there_are_any": True}),
+            {"children[2].previous_addresses.there_are_any": True},
+        )
+
+    def test_modeled_sequence_controls_repeated_list_answers(self):
+        question = {
+            "fields": [{
+                "variable_name": "items.there_is_another",
+                "datatype": "yesnoradio",
+            }]
+        }
+        positions = {}
+        variables = {"items.there_is_another": {"$sequence": [True, False]}}
+        self.assertEqual(build_answer(question, variables, positions), {"items.there_is_another": True})
+        self.assertEqual(build_answer(question, variables, positions), {"items.there_is_another": False})
+        with self.assertRaisesRegex(ValueError, "sequence exhausted"):
+            build_answer(question, variables, positions)
 
     def test_consecutive_repeated_state_is_a_hang_failure(self):
         stuck = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -7,6 +7,7 @@ from runtime_driver import (
     Limits,
     build_answer,
     field_within_cardinalities,
+    question_source_file,
     run_scenario,
     serialized_collection_count,
     serialized_object_choices,
@@ -79,6 +80,27 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_question_source_file_uses_included_file_history(self):
+        question = {
+            "source": {
+                "history": {
+                    "source_file": "docassemble.child:data/questions/child.yml",
+                    "source_code": "question: Child question",
+                },
+                "readability": {"score": 1},
+            }
+        }
+        self.assertEqual(
+            question_source_file(question, SCENARIO["interview"]),
+            "docassemble.child:data/questions/child.yml",
+        )
+
+    def test_question_source_file_falls_back_to_root_interview(self):
+        self.assertEqual(
+            question_source_file({"source": {"history": {}}}, SCENARIO["interview"]),
+            SCENARIO["interview"],
+        )
+
     def test_serialized_collection_count(self):
         self.assertEqual(
             serialized_collection_count({"_class": "DAList", "elements": [{}, {}]}),

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -13,6 +13,7 @@ from runtime_driver import (
     serialized_object_choices,
     serialized_path_cardinality,
     serialized_path_value,
+    source_document_fingerprint,
 )
 
 
@@ -100,6 +101,17 @@ class RuntimeDriverTests(unittest.TestCase):
             question_source_file({"source": {"history": {}}}, SCENARIO["interview"]),
             SCENARIO["interview"],
         )
+
+    def test_source_document_fingerprint_ignores_yaml_formatting(self):
+        first = {"source": {"history": {"source_code": "id: one\nquestion: Hello\n"}}}
+        second = {"source": {"history": {"source_code": "question: Hello\nid: one\n"}}}
+        self.assertEqual(
+            source_document_fingerprint(first),
+            source_document_fingerprint(second),
+        )
+
+    def test_source_document_fingerprint_requires_debug_source(self):
+        self.assertIsNone(source_document_fingerprint({"source": {"history": {}}}))
 
     def test_serialized_collection_count(self):
         self.assertEqual(

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -10,6 +10,7 @@ from runtime_driver import (
     field_within_cardinalities,
     question_variable,
     question_source_file,
+    resolve_generic,
     run_scenario,
     serialized_collection_count,
     serialized_object_choice,
@@ -120,6 +121,61 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
+    def test_generic_object_field_resolves_to_nested_list(self):
+        self.assertEqual(
+            resolve_generic(
+                "x.selected_types",
+                "users[0].income_list.selected_types",
+            ),
+            "users[0].income_list.selected_types",
+        )
+
+    def test_generic_list_item_fields_resolve_to_same_nested_element(self):
+        sought = "users[1].expense_list[2].source"
+        self.assertEqual(
+            resolve_generic("x[i].source", sought),
+            "users[1].expense_list[2].source",
+        )
+        self.assertEqual(
+            resolve_generic("x[i].value", sought),
+            "users[1].expense_list[2].value",
+        )
+
+    def test_generic_nested_name_fields_keep_the_object_root(self):
+        sought = "other_parties[0].name.first"
+        self.assertEqual(
+            resolve_generic("x.name.last", sought),
+            "other_parties[0].name.last",
+        )
+
+    def test_generic_nested_checkboxes_use_the_concrete_scenario_value(self):
+        question = {
+            "event_list": ["users[0].income_list.selected_types"],
+            "fields": [
+                {
+                    "variable_name": "x.selected_types",
+                    "datatype": "checkboxes",
+                    "choices": [
+                        {
+                            "label": "Wages",
+                            "value": True,
+                            "variable_name": "x.selected_types['wages']",
+                        }
+                    ],
+                }
+            ],
+        }
+        answer = build_answer(
+            question,
+            {"users[0].income_list.selected_types": {"wages": True}},
+        )
+        self.assertEqual(set(answer), {"x.selected_types"})
+        self.assertEqual(
+            answer["x.selected_types"]["instanceName"],
+            "users[0].income_list.selected_types",
+        )
+        self.assertEqual(answer["x.selected_types"]["elements"], {"wages": True})
+
     def test_question_variable_prefers_concrete_event_for_generic_screen(self):
         question = {
             "question_variable_name": "users[i].income_schedule_triggers",

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -135,6 +135,18 @@ class RuntimeDriverTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "sequence exhausted"):
             build_answer(question, variables, positions)
 
+    def test_code_button_uses_the_diversion_event_variable(self):
+        question = {
+            "id": "warning",
+            "questionType": "multiple_choice",
+            "event_list": ["warning_acknowledged"],
+            "fields": [],
+        }
+        self.assertEqual(
+            build_answer(question, {}),
+            {"warning_acknowledged": True},
+        )
+
     def test_consecutive_repeated_state_is_a_hang_failure(self):
         stuck = {
             "id": "same screen",
@@ -194,6 +206,23 @@ class RuntimeDriverTests(unittest.TestCase):
         scenario = {**SCENARIO, "expected_terminal_ids": ["download divorce joint petition"]}
         result = run_scenario(FakeClient([terminal]), scenario, limits())
         self.assertEqual(result["failure"], "unexpected_terminal")
+
+    def test_terminal_bundle_evidence_mismatch_fails(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "expected_terminal_evidence": {"include_financial_statement": True},
+        }
+        result = run_scenario(FakeClient([terminal]), scenario, limits())
+        self.assertEqual(result["failure"], "terminal_evidence_mismatch")
+        self.assertEqual(
+            result["terminal_evidence_mismatches"]["include_financial_statement"],
+            {"expected": True, "observed": "<missing>"},
+        )
 
     def test_declared_event_probe_adds_its_screen_to_coverage(self):
         terminal = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -12,6 +12,7 @@ from runtime_driver import (
     question_source_file,
     run_scenario,
     serialized_collection_count,
+    serialized_object_choice,
     serialized_object_choices,
     serialized_path_cardinality,
     serialized_path_value,
@@ -506,6 +507,21 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertTrue(result["gathered"])
         self.assertFalse(result["there_is_another"])
 
+    def test_single_object_choice_is_serialized_from_current_variables(self):
+        court = {
+            "_class": "docassemble.AssemblyLine.al_general.ALCourt",
+            "instanceName": "all_courts[52]",
+            "name": "Essex Probate and Family Court",
+        }
+        result = serialized_object_choice(
+            "trial_court",
+            [{"label": court["name"], "value": "all_courts[52]"}],
+            "all_courts[52]",
+            {"all_courts": {"elements": [None] * 52 + [court]}},
+        )
+        self.assertEqual(result, court)
+        self.assertIsNot(result, court)
+
     def test_settrue_field_defaults_to_boolean_true(self):
         question = {
             "questionType": "settrue",
@@ -602,6 +618,26 @@ class RuntimeDriverTests(unittest.TestCase):
             },
         )
 
+    def test_object_radio_is_omitted_when_same_screen_builds_nested_object(self):
+        question = {
+            "event_list": ["children[0].gals[0].name.first"],
+            "fields": [
+                {
+                    "variable_name": "children[i].gals[j]",
+                    "datatype": "object_radio",
+                    "choices": [{"label": "Someone else", "value": "Someone else"}],
+                },
+                {
+                    "variable_name": "children[i].gals[j].name.first",
+                    "datatype": "text",
+                },
+            ],
+        }
+        self.assertEqual(
+            build_answer(question, {}),
+            {"children[0].gals[0].name.first": "Test"},
+        )
+
     def test_build_answer_omits_rows_beyond_modeled_count(self):
         question = {
             "fields": [
@@ -646,6 +682,33 @@ class RuntimeDriverTests(unittest.TestCase):
         }
         answer = build_answer(question, {"documented": False, "format": "wait"})
         self.assertEqual(answer, {"documented": False, "format": "wait"})
+
+    def test_unconditional_duplicate_field_survives_hidden_conditional_variant(self):
+        question = {
+            "fields": [
+                {"variable_name": "user_grade_school_completed", "datatype": "boolean"},
+                {"variable_name": "show_grade_detail", "datatype": "boolean"},
+                {
+                    "variable_name": "user_grade_school_completed",
+                    "datatype": "boolean",
+                    "show_if_var": "show_grade_detail",
+                    "show_if_val": "True",
+                },
+            ]
+        }
+        self.assertEqual(
+            build_answer(
+                question,
+                {
+                    "user_grade_school_completed": True,
+                    "show_grade_detail": False,
+                },
+            ),
+            {
+                "user_grade_school_completed": True,
+                "show_grade_detail": False,
+            },
+        )
 
     def test_hide_if_field_is_kept_when_condition_does_not_match(self):
         question = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -3,7 +3,13 @@ from unittest.mock import patch
 
 import requests
 
-from runtime_driver import Limits, build_answer, run_scenario, serialized_collection_count
+from runtime_driver import (
+    Limits,
+    build_answer,
+    run_scenario,
+    serialized_collection_count,
+    serialized_path_cardinality,
+)
 
 
 SCENARIO = {
@@ -77,6 +83,20 @@ class RuntimeDriverTests(unittest.TestCase):
         )
         self.assertEqual(serialized_collection_count([]), 0)
         self.assertIsNone(serialized_collection_count("not a collection"))
+
+    def test_serialized_nested_collection_cardinalities(self):
+        variables = {
+            "children": {
+                "elements": [
+                    {"previous_addresses": {"elements": [{}, {}]}},
+                    {"previous_addresses": {"elements": []}},
+                ]
+            }
+        }
+        self.assertEqual(
+            serialized_path_cardinality(variables, "children[*].previous_addresses"),
+            [2, 0],
+        )
 
     def test_settrue_field_defaults_to_boolean_true(self):
         question = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -98,6 +98,13 @@ class RuntimeDriverTests(unittest.TestCase):
             [2, 0],
         )
 
+    def test_missing_nested_collection_serializes_as_zero(self):
+        variables = {"children": {"elements": [{}, {}]}}
+        self.assertEqual(
+            serialized_path_cardinality(variables, "children[*].previous_addresses"),
+            [0, 0],
+        )
+
     def test_settrue_field_defaults_to_boolean_true(self):
         question = {
             "questionType": "settrue",
@@ -174,6 +181,29 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertEqual(
             build_answer(question, {"children[i].previous_addresses.there_are_any": True}),
             {"children[2].previous_addresses.there_are_any": True},
+        )
+
+    def test_event_list_resolves_source_iterator_to_concrete_index(self):
+        question = {
+            "event_list": ["users[1].employer_address_street"],
+            "fields": [
+                {
+                    "variable_name": "users[i].employer_address.address",
+                    "datatype": "text",
+                },
+                {
+                    "variable_name": "users[i].employer_address.city",
+                    "datatype": "text",
+                },
+            ],
+        }
+        self.assertEqual(
+            build_answer(question, {}),
+            {
+                "users[1].employer_address.address": "Test",
+                "users[1].employer_address.city": "Test",
+                "users[1].employer_address_street": True,
+            },
         )
 
     def test_modeled_sequence_controls_repeated_list_answers(self):
@@ -332,6 +362,29 @@ class RuntimeDriverTests(unittest.TestCase):
             result["cardinality_evidence_mismatches"]["children"]["observed"],
             1,
         )
+
+    def test_absent_optional_collection_counts_as_zero(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "expected_cardinalities": {
+                "children": {"variable": "children", "expected": 0},
+            },
+        }
+        result = run_scenario(
+            FakeClient(
+                [terminal],
+                terminal_variables={"divorcejointpetition_downloads_ready": True},
+            ),
+            scenario,
+            limits(),
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["cardinality_evidence"]["children"]["observed"], 0)
 
     def test_declared_event_probe_adds_its_screen_to_coverage(self):
         terminal = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -285,6 +285,37 @@ class RuntimeDriverTests(unittest.TestCase):
             {"children[0].has_gal": False},
         )
 
+    def test_explicit_sought_hidden_value_is_submitted_for_api_traversal(self):
+        question = {
+            "event_list": ["children[0].gals.target_number"],
+            "fields": [
+                {
+                    "variable_name": "children[i].has_gal",
+                    "datatype": "threestate",
+                    "inputtype": "yesnomaybe",
+                },
+                {
+                    "variable_name": "children[i].gals.target_number",
+                    "datatype": "integer",
+                    "show_if_var": "children[i].has_gal",
+                    "show_if_val": "True",
+                },
+            ],
+        }
+        self.assertEqual(
+            build_answer(
+                question,
+                {
+                    "children[i].has_gal": False,
+                    "children[i].gals.target_number": 0,
+                },
+            ),
+            {
+                "children[0].has_gal": False,
+                "children[0].gals.target_number": 0,
+            },
+        )
+
     def test_build_answer_omits_rows_beyond_modeled_count(self):
         question = {
             "fields": [
@@ -463,6 +494,16 @@ class RuntimeDriverTests(unittest.TestCase):
             limits(),
         )
         self.assertEqual(result["failure"], "request_timeout")
+
+    def test_http_error_records_status_and_response_body(self):
+        response = requests.Response()
+        response.status_code = 400
+        response._content = b"Failure to assemble interview"
+        error = requests.HTTPError("400 Client Error", response=response)
+        result = run_scenario(FakeClient([error]), SCENARIO, limits())
+        self.assertEqual(result["failure"], "http_error")
+        self.assertEqual(result["response_status_code"], 400)
+        self.assertEqual(result["response"], "Failure to assemble interview")
 
     def test_error_screen_fails(self):
         error = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -72,7 +72,16 @@ class FakeClient:
     ):
         return {}
 
-    def snapshot(self, interview, session, secret, *, values=None, counts=None):
+    def snapshot(
+        self,
+        interview,
+        session,
+        secret,
+        *,
+        values=None,
+        counts=None,
+        files=None,
+    ):
         result = {
             name: self.terminal_variables[name]
             for name in (values or [])
@@ -84,6 +93,11 @@ class FakeClient:
             value = self.terminal_variables[name]
             count = serialized_collection_count(value)
             result[name] = value if count is None else count
+        if files:
+            result["uploaded_files"] = {
+                name: {"retrievable": True, "filename": "fixture.pdf"}
+                for name in files
+            }
         return result
 
     def action(self, interview, session, secret, action, arguments=None):
@@ -178,6 +192,47 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertEqual(post_data["question"], 0)
         self.assertEqual(post_data["variables"], '{"answer":true}')
         client.http.get.assert_called_once()
+
+    def test_client_upload_uses_single_evaluated_api_request(self):
+        client = Client("http://server", "key", 10)
+        client.http = Mock()
+        client.http.post.return_value = Mock(
+            json=Mock(return_value={"id": "next"})
+        )
+        result = client.answer(
+            "docassemble.example:data/questions/main.yml",
+            "session",
+            "secret",
+            {
+                "uploaded_document": {
+                    "$file": "docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf"
+                }
+            },
+        )
+
+        self.assertEqual(result, {"id": "next"})
+        post_data = client.http.post.call_args.kwargs["data"]
+        self.assertEqual(post_data["question"], 1)
+        self.assertIn("uploaded_document", client.http.post.call_args.kwargs["files"])
+        client.http.get.assert_not_called()
+
+    def test_declared_early_terminal_passes_without_packet_assertions(self):
+        terminal = {
+            "id": "taxes no agreement exit",
+            "questionType": "deadend",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "expected_terminal_ids": ["taxes no agreement exit"],
+            "terminal_assertions": False,
+        }
+
+        result = run_scenario(FakeClient([terminal]), scenario, limits())
+
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["terminal_id"], "taxes no agreement exit")
+        self.assertNotIn("terminal_evidence", result)
 
     def test_bundle_membership_mismatch_fails_terminal(self):
         terminal = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -11,7 +11,6 @@ from runtime_driver import (
     question_source_file,
     run_scenario,
     serialized_collection_count,
-    serialized_download_evidence,
     serialized_object_choices,
     serialized_path_cardinality,
     serialized_path_value,
@@ -135,22 +134,27 @@ class RuntimeDriverTests(unittest.TestCase):
             "questionType": "event",
             "fields": [],
         }
-        file_value = {
-            "_class": "docassemble.base.util.DAFile",
-            "filename": "required.pdf",
-            "extension": "pdf",
-            "ok": True,
-        }
         client = FakeClient(
             [terminal],
             terminal_variables={
                 "divorcejointpetition_downloads_ready": True,
                 "combined_bundle_enabled_document_names": ["required_attachment"],
-                "combined_bundle_downloadable_files": [
-                    [{"title": "Required", "pdf": file_value}],
-                    None,
-                    None,
-                ],
+                "combined_bundle_download_evidence": {
+                    "documents": [
+                        {
+                            "title": "Required",
+                            "files": [
+                                {
+                                    "format": "pdf",
+                                    "filename": "required.pdf",
+                                    "extension": "pdf",
+                                    "ok": True,
+                                }
+                            ],
+                        }
+                    ],
+                    "bundle_files": [],
+                },
             },
         )
         scenario = {
@@ -161,20 +165,43 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertEqual(result["status"], "pass")
         self.assertIsNone(result["failure"])
 
-    def test_download_evidence_reads_only_background_results(self):
-        file_value = {
-            "_class": "docassemble.base.util.DAFile",
-            "filename": "petition.pdf",
-            "extension": "pdf",
-            "ok": True,
-            "file_info": {"pages": 2},
+    def test_download_evidence_requires_explicit_file_success(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
         }
-        evidence = serialized_download_evidence(
-            [[{"title": "Petition", "pdf": file_value}], None, file_value]
+        client = FakeClient(
+            [terminal],
+            terminal_variables={
+                "divorcejointpetition_downloads_ready": True,
+                "combined_bundle_enabled_document_names": ["required_attachment"],
+                "combined_bundle_download_evidence": {
+                    "documents": [
+                        {
+                            "title": "Required",
+                            "files": [
+                                {
+                                    "format": "pdf",
+                                    "filename": "required.pdf",
+                                    "extension": "pdf",
+                                }
+                            ],
+                        }
+                    ],
+                    "bundle_files": [],
+                },
+            },
         )
-        self.assertEqual(evidence["documents"][0]["title"], "Petition")
-        self.assertEqual(evidence["documents"][0]["files"][0]["pages"], 2)
-        self.assertEqual(len(evidence["bundle_files"]), 1)
+        scenario = {
+            **SCENARIO,
+            "expected_bundle_documents": {"required_attachment": True},
+        }
+        result = run_scenario(client, scenario, limits())
+        self.assertEqual(result["failure"], "bundle_document_mismatch")
+        self.assertIn(
+            "<failed-downloads>", result["bundle_document_mismatches"]
+        )
 
     def test_question_source_file_uses_included_file_history(self):
         question = {

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -40,12 +40,19 @@ def limits(**overrides):
 
 
 class FakeClient:
-    def __init__(self, questions, actions=None, terminal_variables=None):
+    def __init__(
+        self,
+        questions,
+        actions=None,
+        terminal_variables=None,
+        uploaded_file_evidence=None,
+    ):
         self.questions = iter(questions)
         self.actions = actions or {}
         self.terminal_variables = terminal_variables or {
             "divorcejointpetition_downloads_ready": True,
         }
+        self.uploaded_file_evidence = uploaded_file_evidence
         self.pending_action = None
 
     def new_session(self, interview):
@@ -95,7 +102,11 @@ class FakeClient:
             result[name] = value if count is None else count
         if files:
             result["uploaded_files"] = {
-                name: {"retrievable": True, "filename": "fixture.pdf"}
+                name: (
+                    self.uploaded_file_evidence.get(name, {})
+                    if self.uploaded_file_evidence is not None
+                    else {"retrievable": True, "filename": "fixture.pdf"}
+                )
                 for name in files
             }
         return result
@@ -320,6 +331,33 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertEqual(result["failure"], "bundle_document_mismatch")
         self.assertIn(
             "<failed-downloads>", result["bundle_document_mismatches"]
+        )
+
+    def test_uploaded_file_must_remain_retrievable_at_terminal(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        client = FakeClient(
+            [terminal],
+            uploaded_file_evidence={"uploaded_document": {"retrievable": False}},
+        )
+        scenario = {
+            **SCENARIO,
+            "variables": {
+                "uploaded_document": {
+                    "$file": "docassemble/MATC1ADivorceJointPetition/data/templates/r408.pdf"
+                }
+            },
+        }
+
+        result = run_scenario(client, scenario, limits())
+
+        self.assertEqual(result["failure"], "uploaded_file_not_retrievable")
+        self.assertEqual(
+            result["failed_uploads"],
+            {"uploaded_document": {"retrievable": False}},
         )
 
     def test_question_source_file_uses_included_file_history(self):

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -10,7 +10,7 @@ from runtime_driver import (
     question_source_file,
     run_scenario,
     serialized_collection_count,
-    serialized_bundle_evidence,
+    serialized_download_evidence,
     serialized_object_choices,
     serialized_path_cardinality,
     serialized_path_value,
@@ -71,8 +71,19 @@ class FakeClient:
     ):
         return {}
 
-    def variables(self, interview, session, secret):
-        return self.terminal_variables
+    def snapshot(self, interview, session, secret, *, values=None, counts=None):
+        result = {
+            name: self.terminal_variables[name]
+            for name in (values or [])
+            if name in self.terminal_variables
+        }
+        for name in counts or []:
+            if name not in self.terminal_variables:
+                continue
+            value = self.terminal_variables[name]
+            count = serialized_collection_count(value)
+            result[name] = value if count is None else count
+        return result
 
     def action(self, interview, session, secret, action, arguments=None):
         self.pending_action = action
@@ -82,39 +93,6 @@ class FakeClient:
 
 
 class RuntimeDriverTests(unittest.TestCase):
-    def test_serialized_bundle_evidence_records_exact_generated_files(self):
-        bundle = {
-            "_class": "docassemble.AssemblyLine.al_document.ALDocumentBundle",
-            "elements": [
-                {
-                    "instanceName": "included_attachment",
-                    "always_enabled": False,
-                    "cache": {"enabled": True},
-                    "elements": {
-                        "preview": {
-                            "pdf": {
-                                "_class": "docassemble.base.util.DAFile",
-                                "filename": "included.pdf",
-                                "extension": "pdf",
-                                "ok": True,
-                                "file_info": {"pages": 2},
-                            }
-                        }
-                    },
-                },
-                {
-                    "instanceName": "excluded_attachment",
-                    "always_enabled": False,
-                    "cache": {"enabled": False},
-                    "elements": {},
-                },
-            ],
-        }
-        evidence = serialized_bundle_evidence(bundle)
-        self.assertTrue(evidence["included_attachment"]["generated"])
-        self.assertEqual(evidence["included_attachment"]["files"][0]["pages"], 2)
-        self.assertFalse(evidence["excluded_attachment"]["generated"])
-
     def test_bundle_membership_mismatch_fails_terminal(self):
         terminal = {
             "id": "download divorce joint petition",
@@ -127,6 +105,53 @@ class RuntimeDriverTests(unittest.TestCase):
         }
         result = run_scenario(FakeClient([terminal]), scenario, limits())
         self.assertEqual(result["failure"], "bundle_document_mismatch")
+
+    def test_exact_enabled_bundle_and_background_download_pass_terminal(self):
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        file_value = {
+            "_class": "docassemble.base.util.DAFile",
+            "filename": "required.pdf",
+            "extension": "pdf",
+            "ok": True,
+        }
+        client = FakeClient(
+            [terminal],
+            terminal_variables={
+                "divorcejointpetition_downloads_ready": True,
+                "combined_bundle_enabled_document_names": ["required_attachment"],
+                "al_user_bundle._downloadable_files": [
+                    [{"title": "Required", "pdf": file_value}],
+                    None,
+                    None,
+                ],
+            },
+        )
+        scenario = {
+            **SCENARIO,
+            "expected_bundle_documents": {"required_attachment": True},
+        }
+        result = run_scenario(client, scenario, limits())
+        self.assertEqual(result["status"], "pass")
+        self.assertIsNone(result["failure"])
+
+    def test_download_evidence_reads_only_background_results(self):
+        file_value = {
+            "_class": "docassemble.base.util.DAFile",
+            "filename": "petition.pdf",
+            "extension": "pdf",
+            "ok": True,
+            "file_info": {"pages": 2},
+        }
+        evidence = serialized_download_evidence(
+            [[{"title": "Petition", "pdf": file_value}], None, file_value]
+        )
+        self.assertEqual(evidence["documents"][0]["title"], "Petition")
+        self.assertEqual(evidence["documents"][0]["files"][0]["pages"], 2)
+        self.assertEqual(len(evidence["bundle_files"]), 1)
 
     def test_question_source_file_uses_included_file_history(self):
         question = {
@@ -313,6 +338,33 @@ class RuntimeDriverTests(unittest.TestCase):
             {
                 "children[0].has_gal": False,
                 "children[0].gals.target_number": 0,
+            },
+        )
+
+    def test_object_choice_is_omitted_when_same_screen_builds_nested_object(self):
+        question = {
+            "event_list": ["children[0].address.address"],
+            "fields": [
+                {
+                    "variable_name": "children[i].address",
+                    "datatype": "object",
+                    "choices": [{"label": "Home", "value": "marital_home"}],
+                },
+                {
+                    "variable_name": "children[i].address.address",
+                    "datatype": "text",
+                },
+                {
+                    "variable_name": "children[i].address.city",
+                    "datatype": "text",
+                },
+            ],
+        }
+        self.assertEqual(
+            build_answer(question, {}),
+            {
+                "children[0].address.address": "Test",
+                "children[0].address.city": "Test",
             },
         )
 

--- a/tests/certification/test_runtime_driver.py
+++ b/tests/certification/test_runtime_driver.py
@@ -245,6 +245,33 @@ class RuntimeDriverTests(unittest.TestCase):
         self.assertEqual(result["terminal_id"], "taxes no agreement exit")
         self.assertNotIn("terminal_evidence", result)
 
+    def test_route_screen_expectations_reject_wrong_signer(self):
+        wrong_signer = {
+            "id": "sign party A",
+            "questionType": "signature",
+            "fields": [
+                {"variable_name": "users[0].signature", "datatype": "signature"}
+            ],
+        }
+        terminal = {
+            "id": "download divorce joint petition",
+            "questionType": "event",
+            "fields": [],
+        }
+        scenario = {
+            **SCENARIO,
+            "required_screen_ids": ["sign attorney for party A"],
+            "forbidden_screen_ids": ["sign party A"],
+        }
+
+        result = run_scenario(FakeClient([wrong_signer, terminal]), scenario, limits())
+
+        self.assertEqual(result["failure"], "screen_expectation_mismatch")
+        self.assertEqual(
+            result["missing_required_screen_ids"], ["sign attorney for party A"]
+        )
+        self.assertEqual(result["forbidden_screen_ids_seen"], ["sign party A"])
+
     def test_bundle_membership_mismatch_fails_terminal(self):
         terminal = {
             "id": "download divorce joint petition",

--- a/tests/certification/test_verify_runtime_manifest.py
+++ b/tests/certification/test_verify_runtime_manifest.py
@@ -1,0 +1,41 @@
+import unittest
+
+from verify_runtime_manifest import freeze_digest, verify
+
+
+BASELINE = {
+    "runtime": {"image": "example/image@sha256:abc"},
+    "external_packages": {"docassemble.Example": "1.2.3"},
+}
+
+
+class RuntimeManifestTests(unittest.TestCase):
+    def test_freeze_digest_is_order_and_case_stable(self):
+        self.assertEqual(
+            freeze_digest("Zulu==2\nalpha==1\n"),
+            freeze_digest("ALPHA==1\nzulu==2\n"),
+        )
+
+    def test_exact_manifest_passes(self):
+        self.assertEqual(
+            verify(
+                BASELINE,
+                ["example/image@sha256:abc"],
+                "docassemble.Example==1.2.3\n",
+            ),
+            [],
+        )
+
+    def test_image_and_package_drift_fail(self):
+        errors = verify(
+            BASELINE,
+            ["example/image@sha256:different"],
+            "docassemble.Example==2.0.0\n",
+        )
+        self.assertEqual(len(errors), 2)
+        self.assertIn("runtime image mismatch", errors[0])
+        self.assertIn("package mismatch", errors[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/certification/verify_runtime_manifest.py
+++ b/tests/certification/verify_runtime_manifest.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Verify that a runtime used the exact declared image and external packages."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def parse_freeze(text: str) -> dict[str, str]:
+    result = {}
+    for line in text.splitlines():
+        if "==" not in line:
+            continue
+        name, version = line.split("==", 1)
+        result[name.lower()] = version
+    return result
+
+
+def freeze_digest(text: str) -> str:
+    installed = parse_freeze(text)
+    normalized = "".join(
+        f"{name}=={version}\n" for name, version in sorted(installed.items())
+    )
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def verify(baseline: dict, image_digests: list[str], freeze_text: str) -> list[str]:
+    errors = []
+    expected_image = baseline["runtime"]["image"]
+    if expected_image not in image_digests:
+        errors.append(f"runtime image mismatch: expected {expected_image}, got {image_digests}")
+
+    installed = parse_freeze(freeze_text)
+    for package, expected_version in baseline["external_packages"].items():
+        actual_version = installed.get(package.lower())
+        if actual_version != expected_version:
+            errors.append(
+                f"package mismatch for {package}: expected {expected_version}, got {actual_version}"
+            )
+    expected_freeze_digest = baseline["runtime"].get("pip_freeze_sha256")
+    actual_freeze_digest = freeze_digest(freeze_text)
+    if expected_freeze_digest and actual_freeze_digest != expected_freeze_digest:
+        errors.append(
+            "pip freeze mismatch: "
+            f"expected {expected_freeze_digest}, got {actual_freeze_digest}"
+        )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", type=Path, default=HERE / "baseline.json")
+    parser.add_argument("--image", type=Path, required=True)
+    parser.add_argument("--pip-freeze", type=Path, required=True)
+    args = parser.parse_args()
+
+    errors = verify(
+        json.loads(args.baseline.read_text()),
+        json.loads(args.image.read_text()),
+        args.pip_freeze.read_text(),
+    )
+    if errors:
+        print("\n".join(errors))
+        return 1
+    print("runtime manifest matches baseline")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Outcome

The combined 1A interview now has a deterministic certification gate and completes every modeled route in a disposable Docassemble runtime.

No merge and no shared Suffolk Docassemble server were used.

## What changed

- pins the complete combined-interview package graph and Docker image
- catalogs exact YAML screen coordinates across the parent and included feature packages
- models the finite branch and list-cardinality equivalence classes
- drives fresh API sessions and records every screen transition, answer, upload, signer, terminal state, enabled document, and generated download
- rejects HTTP failures, Docassemble error screens, loops, timeouts, packet mismatches, upload failures, signer-routing errors, and background-worker task errors
- fixes combined-interview blockers found by the crawl, including merge-agreement/R408 traversal, party identity, packet cache state, multi-child custody selection, and financial list ownership/indexing

## Final validation

- 96 local harness and regression tests pass
- pinned graph: 37 YAML files, 572 declared screens overall
- exact combined-feature denominator: 405 local screen coordinates
- 42/42 modeled routes pass with 0 failures
- 295 local coordinates observed at runtime
- 110 coordinates source-proven unreachable from the combined parent
- 0 missing screens, modeled paths, or cardinality classes
- 0 stale, unsupported, or runtime-contradicted exclusions
- exact packet membership, download formats, upload evidence, and represented/unrepresented signer routing pass
- background-worker error gate passes
- final run: https://github.com/SuffolkLITLab/docassemble-MATC1ADivorceJointPetition/actions/runs/32492514050

The earlier “191 screens” count was a preliminary reachable/unclassified slice. The final denominator is the exact 405-coordinate local feature catalog above.

## Dependencies

- financial list and nested-item fixes: SuffolkLITLab/docassemble-MATCFinancialStatement#23
- multi-child care/custody serialization fix: SuffolkLITLab/docassemble-MATCChildCareOrCustodyDisclosureAffidavit#3

Addresses the runtime-certification portion of #138. Student document planning remains separate in #121.
